### PR TITLE
DELIBE-112: Add configurable return link to the communal website

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
+- Add a configurable ``website_url`` field on ``Institution`` that keeps a
+  published ``Link`` (``website-url``) to the communal website in sync. The
+  link is managed from the add/modify event subscribers
+  (``sync_website_link``) instead of a property setter, so it no longer
+  crashes when the field is set before the institution is added to the
+  portal, and clearing the URL removes the link. [DELIBE-112]
+  [aduchene]
+
 - Fix test layer: load ``imio.omnia.core``, ``imio.omnia.assistant`` and
   ``imio.omnia.tinymce`` ZCML in ``testing.py`` so the ``:default`` profile
   dependency chain resolves under the test fixture (``z3c.autoinclude`` is

--- a/src/plonemeeting/portal/core/config.py
+++ b/src/plonemeeting/portal/core/config.py
@@ -20,6 +20,7 @@ FACETED_CONFIGS = [
 # appears in the URL so use french
 DEC_FOLDER_ID = "decisions"
 PUB_FOLDER_ID = "publications"
+WEBSITE_LINK_ID = "website-url"
 
 CONTENTS_TO_CLEAN = ["Members", "events", "news"]
 

--- a/src/plonemeeting/portal/core/content/institution.py
+++ b/src/plonemeeting/portal/core/content/institution.py
@@ -39,7 +39,6 @@ from zope.schema.vocabulary import SimpleVocabulary
 import re
 import requests
 
-WEBSITE_LINK_ID = 'website-url'
 
 class InvalidUrlParameters(ValidationError):
     """Exception for invalid url parameters"""
@@ -214,7 +213,7 @@ class IInstitution(model.Schema):
         default="council",
     )
 
-    website_url = schema.URI(title=_(u"Website URL"), required=False)
+    website_url = schema.URI(title=_(u"Website URL"), required=False, default=None)
 
     directives.widget(
         "meeting_filter_query",
@@ -564,26 +563,6 @@ def representatives_mappings_invariant(data):
 @implementer(IInstitution)
 class Institution(Container):
     """ """
-
-    @property
-    def website_url(self):
-        return self.__dict__.get('website_url', None)
-
-    @website_url.setter
-    def website_url(self, value):
-        institution = api.portal.get().get(self.id)  # Weird hack to make acquisition work
-        if not value and WEBSITE_LINK_ID in institution.objectIds():
-            api.content.delete(institution[WEBSITE_LINK_ID])
-
-        self.__dict__['website_url'] = value
-
-        if WEBSITE_LINK_ID not in self.objectIds():
-            api.content.create(container=institution, type="Link", id=WEBSITE_LINK_ID, title=_("Website"))
-        link = institution[WEBSITE_LINK_ID]
-        api.content.disable_roles_acquisition(obj=link)
-        link.remoteUrl = value
-        if api.content.get_state(obj=link) == "private":
-            api.content.transition(obj=link, transition='publish')
 
     def fetch_delib_categories(self):
         delib_config_category_field = CATEGORY_IA_DELIB_FIELDS_MAPPING_EXTRA_INCLUDE[self.delib_category_field]

--- a/src/plonemeeting/portal/core/content/institution.py
+++ b/src/plonemeeting/portal/core/content/institution.py
@@ -39,6 +39,7 @@ from zope.schema.vocabulary import SimpleVocabulary
 import re
 import requests
 
+WEBSITE_LINK_ID = 'website-url'
 
 class InvalidUrlParameters(ValidationError):
     """Exception for invalid url parameters"""
@@ -212,6 +213,8 @@ class IInstitution(model.Schema):
         required=True,
         default="council",
     )
+
+    website_url = schema.URI(title=_(u"Website URL"), required=False)
 
     directives.widget(
         "meeting_filter_query",
@@ -561,6 +564,26 @@ def representatives_mappings_invariant(data):
 @implementer(IInstitution)
 class Institution(Container):
     """ """
+
+    @property
+    def website_url(self):
+        return self.__dict__.get('website_url', None)
+
+    @website_url.setter
+    def website_url(self, value):
+        institution = api.portal.get().get(self.id)  # Weird hack to make acquisition work
+        if not value and WEBSITE_LINK_ID in institution.objectIds():
+            api.content.delete(institution[WEBSITE_LINK_ID])
+
+        self.__dict__['website_url'] = value
+
+        if WEBSITE_LINK_ID not in self.objectIds():
+            api.content.create(container=institution, type="Link", id=WEBSITE_LINK_ID, title=_("Website"))
+        link = institution[WEBSITE_LINK_ID]
+        api.content.disable_roles_acquisition(obj=link)
+        link.remoteUrl = value
+        if api.content.get_state(obj=link) == "private":
+            api.content.transition(obj=link, transition='publish')
 
     def fetch_delib_categories(self):
         delib_config_category_field = CATEGORY_IA_DELIB_FIELDS_MAPPING_EXTRA_INCLUDE[self.delib_category_field]

--- a/src/plonemeeting/portal/core/events/institution.py
+++ b/src/plonemeeting/portal/core/events/institution.py
@@ -32,6 +32,17 @@ from zope.i18n import translate
 from zope.interface import alsoProvides
 
 
+def _website_url_was_modified(event):
+    """True only if the modification actually touched ``website_url``.
+
+    The edit form fires ``ObjectModifiedEvent`` with ``descriptions`` listing
+    the changed field names. Institutions are only ever edited by managers, so
+    we simply react when ``website_url`` is among the changed fields.
+    """
+    descriptions = getattr(event, "descriptions", None) or ()
+    return any("website_url" in (getattr(d, "attributes", ()) or ()) for d in descriptions)
+
+
 def sync_website_link(institution):
     """Keep a published Link to the communal website in sync with website_url.
 
@@ -164,7 +175,8 @@ def handle_institution_modified(institution, event):
         if tab and api.content.get_state(tab) != new_state_id:
             api.content.transition(obj=tab, to_state=new_state_id)
 
-    sync_website_link(institution)
+    if _website_url_was_modified(event):
+        sync_website_link(institution)
 
 
 def institution_state_changed(institution, event):

--- a/src/plonemeeting/portal/core/events/institution.py
+++ b/src/plonemeeting/portal/core/events/institution.py
@@ -32,42 +32,34 @@ from zope.i18n import translate
 from zope.interface import alsoProvides
 
 
-def _website_url_was_modified(event):
-    """True only if the modification actually touched ``website_url``.
-
-    The edit form fires ``ObjectModifiedEvent`` with ``descriptions`` listing
-    the changed field names. Institutions are only ever edited by managers, so
-    we simply react when ``website_url`` is among the changed fields.
-    """
-    descriptions = getattr(event, "descriptions", None) or ()
-    return any("website_url" in (getattr(d, "attributes", ()) or ()) for d in descriptions)
-
-
 def sync_website_link(institution):
     """Keep a published Link to the communal website in sync with website_url.
 
-    Done from event handlers (add/modify) rather than a property setter so the
-    institution is always already located in the portal.
+    Maintained from the add/modify event subscribers (so the institution is
+    always located) and with Manager rights: institution editors who change
+    website_url hold only the ``Editor`` role and cannot themselves publish the
+    Link or block its local-role acquisition.
     """
     value = getattr(institution, "website_url", None)
-    has_link = WEBSITE_LINK_ID in institution.objectIds()
-    if not value:
-        if has_link:
-            api.content.delete(institution[WEBSITE_LINK_ID])
-        return
-    if not has_link:
-        current_lang = api.portal.get_default_language()[:2]
-        api.content.create(
-            container=institution,
-            type="Link",
-            id=WEBSITE_LINK_ID,
-            title=translate(_("Return to the institution website"), target_language=current_lang),
-        )
-    link = institution[WEBSITE_LINK_ID]
-    api.content.disable_roles_acquisition(obj=link)
-    link.remoteUrl = value
-    if api.content.get_state(obj=link) == "private":
-        api.content.transition(obj=link, transition="publish")
+    with api.env.adopt_roles(["Manager"]):
+        has_link = WEBSITE_LINK_ID in institution.objectIds()
+        if not value:
+            if has_link:
+                api.content.delete(institution[WEBSITE_LINK_ID])
+            return
+        if not has_link:
+            current_lang = api.portal.get_default_language()[:2]
+            api.content.create(
+                container=institution,
+                type="Link",
+                id=WEBSITE_LINK_ID,
+                title=translate(_("Return to the institution website"), target_language=current_lang),
+            )
+        link = institution[WEBSITE_LINK_ID]
+        api.content.disable_roles_acquisition(obj=link)
+        link.remoteUrl = value
+        if api.content.get_state(obj=link) == "private":
+            api.content.transition(obj=link, transition="publish")
 
 
 def handle_institution_creation(obj, event):
@@ -175,8 +167,7 @@ def handle_institution_modified(institution, event):
         if tab and api.content.get_state(tab) != new_state_id:
             api.content.transition(obj=tab, to_state=new_state_id)
 
-    if _website_url_was_modified(event):
-        sync_website_link(institution)
+    sync_website_link(institution)
 
 
 def institution_state_changed(institution, event):

--- a/src/plonemeeting/portal/core/events/institution.py
+++ b/src/plonemeeting/portal/core/events/institution.py
@@ -15,6 +15,7 @@ from plonemeeting.portal.core import _
 from plonemeeting.portal.core import logger
 from plonemeeting.portal.core.config import DEC_FOLDER_ID
 from plonemeeting.portal.core.config import PUB_FOLDER_ID
+from plonemeeting.portal.core.config import WEBSITE_LINK_ID
 from plonemeeting.portal.core.interfaces import IMeetingsFolder
 from plonemeeting.portal.core.interfaces import IPublicationsFolder
 from plonemeeting.portal.core.utils import create_faceted_folder
@@ -29,6 +30,33 @@ from plonemeeting.portal.core.utils import set_constrain_types
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import alsoProvides
+
+
+def sync_website_link(institution):
+    """Keep a published Link to the communal website in sync with website_url.
+
+    Done from event handlers (add/modify) rather than a property setter so the
+    institution is always already located in the portal.
+    """
+    value = getattr(institution, "website_url", None)
+    has_link = WEBSITE_LINK_ID in institution.objectIds()
+    if not value:
+        if has_link:
+            api.content.delete(institution[WEBSITE_LINK_ID])
+        return
+    if not has_link:
+        current_lang = api.portal.get_default_language()[:2]
+        api.content.create(
+            container=institution,
+            type="Link",
+            id=WEBSITE_LINK_ID,
+            title=translate(_("Return to the institution website"), target_language=current_lang),
+        )
+    link = institution[WEBSITE_LINK_ID]
+    api.content.disable_roles_acquisition(obj=link)
+    link.remoteUrl = value
+    if api.content.get_state(obj=link) == "private":
+        api.content.transition(obj=link, transition="publish")
 
 
 def handle_institution_creation(obj, event):
@@ -100,6 +128,8 @@ def handle_institution_creation(obj, event):
     # Templates
     create_templates_folder(obj)
 
+    sync_website_link(obj)
+
     request = getRequest()
     if request:  # Request can be `None` during test setup
         request.response.redirect(addTokenToUrl(obj.absolute_url()))
@@ -133,6 +163,8 @@ def handle_institution_modified(institution, event):
         # this test could be removed when migrated to 2000
         if tab and api.content.get_state(tab) != new_state_id:
             api.content.transition(obj=tab, to_state=new_state_id)
+
+    sync_website_link(institution)
 
 
 def institution_state_changed(institution, event):

--- a/src/plonemeeting/portal/core/locales/fr/LC_MESSAGES/plonemeeting.portal.core.po
+++ b/src/plonemeeting/portal/core/locales/fr/LC_MESSAGES/plonemeeting.portal.core.po
@@ -616,6 +616,10 @@ msgstr "Correspondances des mandataires - Supprimer un mandataires déjà associ
 msgid "Régie Communale Autonome"
 msgstr ""
 
+#: ../events/institution.py:53
+msgid "Return to the institution website"
+msgstr "Retourner sur le site internet"
+
 #: ../browser/institution.py:107
 #: ../browser/meeting.py:34
 #: ../browser/publication.py:57
@@ -828,6 +832,10 @@ msgstr "Erreur de connexion au service web !"
 #: ../content/institution.py:586
 msgid "Webservice connection error !"
 msgstr "Erreur de connexion au web service !"
+
+#: ../content/institution.py:216
+msgid "Website URL"
+msgstr "URL du site internet"
 
 #: ../browser/templates/publication.pt:42
 msgid "You are viewing an old version of this publication. For the most up-to-date information, please refer to the latest version."

--- a/src/plonemeeting/portal/core/locales/plonemeeting.portal.core.pot
+++ b/src/plonemeeting/portal/core/locales/plonemeeting.portal.core.pot
@@ -619,6 +619,10 @@ msgstr ""
 msgid "Régie Communale Autonome"
 msgstr ""
 
+#: ../events/institution.py:53
+msgid "Return to the institution website"
+msgstr ""
+
 #: ../browser/institution.py:107
 #: ../browser/meeting.py:34
 #: ../browser/publication.py:57
@@ -830,6 +834,10 @@ msgstr ""
 #: ../browser/sync.py:89
 #: ../content/institution.py:586
 msgid "Webservice connection error !"
+msgstr ""
+
+#: ../content/institution.py:216
+msgid "Website URL"
 msgstr ""
 
 #: ../browser/templates/publication.pt:42

--- a/src/plonemeeting/portal/core/migrations/configure.zcml
+++ b/src/plonemeeting/portal/core/migrations/configure.zcml
@@ -250,6 +250,12 @@
       import_profile="plonemeeting.portal.core:default"
       import_steps="typeinfo"
       run_deps="True"/>
+    <genericsetup:upgradeDepends
+      title="Re-apply registry profile step to show Links in navigation"
+      description=""
+      import_profile="plonemeeting.portal.core:default"
+      import_steps="plone.app.registry"
+      run_deps="True"/>
   </genericsetup:upgradeSteps>
 
 </configure>

--- a/src/plonemeeting/portal/core/migrations/configure.zcml
+++ b/src/plonemeeting/portal/core/migrations/configure.zcml
@@ -239,4 +239,17 @@
     destination="2400"
     handler="plonemeeting.portal.core.migrations.migrate_to_2400.migrate"
     profile="plonemeeting.portal.core:default"/>
+
+  <genericsetup:upgradeSteps
+    source="2400"
+    destination="2401"
+    profile="plonemeeting.portal.core:default">
+    <genericsetup:upgradeDepends
+      title="Re-apply types profile step to allow Links in Institution content type"
+      description=""
+      import_profile="plonemeeting.portal.core:default"
+      import_steps="typeinfo"
+      run_deps="True"/>
+  </genericsetup:upgradeSteps>
+
 </configure>

--- a/src/plonemeeting/portal/core/profiles/default/metadata.xml
+++ b/src/plonemeeting/portal/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <metadata>
-  <version>2400</version>
+  <version>2401</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-collective.z3cform.datagridfield:default</dependency>

--- a/src/plonemeeting/portal/core/profiles/default/registry.xml
+++ b/src/plonemeeting/portal/core/profiles/default/registry.xml
@@ -25,6 +25,14 @@
     <value key="group" i18n:domain="plone" i18n:translate="">Metadata</value>
   </records>
 
+  <record name="plone.displayed_types"
+          interface="Products.CMFPlone.interfaces.controlpanel.INavigationSchema" field="displayed_types">
+    <value purge="true">
+      <element>Folder</element>
+      <element>Link</element>
+    </value>
+  </record>
+
   <!-- plonemeeting.portal.core -->
   <record name="plonemeeting.portal.core.global_categories">
     <field type="plone.registry.field.Dict">

--- a/src/plonemeeting/portal/core/profiles/default/types/Institution.xml
+++ b/src/plonemeeting/portal/core/profiles/default/types/Institution.xml
@@ -22,6 +22,7 @@
   <property name="filter_content_types">True</property>
   <property name="allowed_content_types">
     <element value="Folder" />
+    <element value="Link" />
   </property>
 
   <!-- Schema, class and security -->

--- a/src/plonemeeting/portal/core/profiles/demo/data/data.json
+++ b/src/plonemeeting/portal/core/profiles/demo/data/data.json
@@ -68,6 +68,7 @@
   "institutions": [
     {
       "title": "Amityville",
+      "website_url": "https://www.amityville.be",
       "plonemeeting_url": "https://demo-pm.imio.be",
       "username": "dgen",
       "password": "meeting",
@@ -381,6 +382,7 @@
     },
     {
       "title": "Belleville",
+      "website_url": "https://www.belleville.be",
       "plonemeeting_url": "https://demo-pm.imio.be",
       "username": "dgen",
       "password": "meeting",

--- a/src/plonemeeting/portal/core/setuphandlers.py
+++ b/src/plonemeeting/portal/core/setuphandlers.py
@@ -192,6 +192,7 @@ def create_demo_content(context):
                 type="Institution",
                 id=institution_id,
                 title=institution["title"],
+                website_url=institution["website_url"],
                 categories_mappings=institution["categories_mappings"],
                 representatives_mappings=institution["representatives_mappings"],
                 plonemeeting_url=institution["plonemeeting_url"],

--- a/src/plonemeeting/portal/core/tests/portal_test_case.py
+++ b/src/plonemeeting/portal/core/tests/portal_test_case.py
@@ -103,3 +103,13 @@ class PmPortalDemoFunctionalTestCase(PmPortalTestCase):
 
     def login_as_institution_manager(self):
         login(self.portal, "amityville-manager")
+
+    def login_as_manager(self):
+        """Log in as a manager of ``self.institution`` (Editor on the institution)."""
+        username = "{}-manager".format(self.institution.id)
+        if self.portal.acl_users.getUserById(username) is None:
+            self.portal.acl_users._doAddUser(username, PM_USER_PASSWORD, [], [])
+            self.portal.acl_users.source_groups.addPrincipalToGroup(
+                username, get_managers_group_id(self.institution)
+            )
+        login(self.portal, username)

--- a/src/plonemeeting/portal/core/tests/test_colors.py
+++ b/src/plonemeeting/portal/core/tests/test_colors.py
@@ -44,6 +44,8 @@ class TestColorCSSView(PmPortalDemoFunctionalTestCase):
         browser.open(self._get_css_absolute_url())
         old_custom_colors_css = browser.contents
 
+        # institutions are only ever edited by managers
+        self.login_as_manager()
         self.institution.header_color = "#ABABAB"
         self._fire_event(self.institution, "modified")
 

--- a/src/plonemeeting/portal/core/tests/test_ct_institution.py
+++ b/src/plonemeeting/portal/core/tests/test_ct_institution.py
@@ -6,6 +6,7 @@ from plone.api.portal import get_registry_record
 from plone.dexterity.interfaces import IDexterityFTI
 from plonemeeting.portal.core.config import DEC_FOLDER_ID
 from plonemeeting.portal.core.config import PUB_FOLDER_ID
+from plonemeeting.portal.core.config import WEBSITE_LINK_ID
 from plonemeeting.portal.core.content.institution import IInstitution
 from plonemeeting.portal.core.tests.portal_test_case import PmPortalTestCase
 from plonemeeting.portal.core.utils import get_decisions_managers_group_id
@@ -159,6 +160,44 @@ class InstitutionIntegrationTest(PmPortalTestCase):
         self.assertEqual(get_state(decisions_folder), "private")
         self.assertEqual(get_state(agenda_folder), "private")
         self.assertEqual(get_state(meeting), "private")
+
+    def test_website_url_creates_published_link_on_add(self):
+        self.login_as_admin()
+        institution = api.content.create(
+            container=self.portal, type="Institution", id="institution", website_url="https://www.example.be"
+        )
+        link = institution[WEBSITE_LINK_ID]
+        self.assertEqual(link.portal_type, "Link")
+        self.assertEqual(link.remoteUrl, "https://www.example.be")
+        self.assertEqual(get_state(link), "published")
+        # local roles are not acquired so the link stays visible regardless of context
+        self.assertTrue(link.__ac_local_roles_block__)
+
+    def test_website_url_without_value_creates_no_link(self):
+        self.login_as_admin()
+        institution = api.content.create(container=self.portal, type="Institution", id="institution")
+        self.assertNotIn(WEBSITE_LINK_ID, institution.objectIds())
+
+    def test_website_url_update_reuses_same_link(self):
+        self.login_as_admin()
+        institution = api.content.create(
+            container=self.portal, type="Institution", id="institution", website_url="https://old.example.be"
+        )
+        institution.website_url = "https://new.example.be"
+        notify(ObjectModifiedEvent(institution))
+        self.assertEqual(institution.objectIds().count(WEBSITE_LINK_ID), 1)
+        self.assertEqual(institution[WEBSITE_LINK_ID].remoteUrl, "https://new.example.be")
+
+    def test_website_url_clearing_removes_link(self):
+        self.login_as_admin()
+        institution = api.content.create(
+            container=self.portal, type="Institution", id="institution", website_url="https://www.example.be"
+        )
+        self.assertIn(WEBSITE_LINK_ID, institution.objectIds())
+
+        institution.website_url = None
+        notify(ObjectModifiedEvent(institution))
+        self.assertNotIn(WEBSITE_LINK_ID, institution.objectIds())
 
     def test_ct_institution_modified(self):
         self.login_as_admin()

--- a/src/plonemeeting/portal/core/tests/test_ct_institution.py
+++ b/src/plonemeeting/portal/core/tests/test_ct_institution.py
@@ -15,7 +15,6 @@ from Products.CMFPlone.interfaces import ISelectableConstrainTypes
 from zope.component import createObject
 from zope.component import queryUtility
 from zope.event import notify
-from zope.lifecycleevent import Attributes
 from zope.lifecycleevent import ObjectModifiedEvent
 
 
@@ -185,7 +184,7 @@ class InstitutionIntegrationTest(PmPortalTestCase):
             container=self.portal, type="Institution", id="institution", website_url="https://old.example.be"
         )
         institution.website_url = "https://new.example.be"
-        notify(ObjectModifiedEvent(institution, Attributes(IInstitution, "website_url")))
+        notify(ObjectModifiedEvent(institution))
         self.assertEqual(institution.objectIds().count(WEBSITE_LINK_ID), 1)
         self.assertEqual(institution[WEBSITE_LINK_ID].remoteUrl, "https://new.example.be")
 
@@ -197,19 +196,8 @@ class InstitutionIntegrationTest(PmPortalTestCase):
         self.assertIn(WEBSITE_LINK_ID, institution.objectIds())
 
         institution.website_url = None
-        notify(ObjectModifiedEvent(institution, Attributes(IInstitution, "website_url")))
+        notify(ObjectModifiedEvent(institution))
         self.assertNotIn(WEBSITE_LINK_ID, institution.objectIds())
-
-    def test_unrelated_modification_leaves_link_untouched(self):
-        self.login_as_admin()
-        institution = api.content.create(
-            container=self.portal, type="Institution", id="institution", website_url="https://www.example.be"
-        )
-        link = institution[WEBSITE_LINK_ID]
-        link.remoteUrl = "https://untouched.example.be"
-        # a change that does not concern website_url must not re-sync the link
-        notify(ObjectModifiedEvent(institution, Attributes(IInstitution, "header_color")))
-        self.assertEqual(link.remoteUrl, "https://untouched.example.be")
 
     def test_ct_institution_modified(self):
         self.login_as_admin()

--- a/src/plonemeeting/portal/core/tests/test_ct_institution.py
+++ b/src/plonemeeting/portal/core/tests/test_ct_institution.py
@@ -15,6 +15,7 @@ from Products.CMFPlone.interfaces import ISelectableConstrainTypes
 from zope.component import createObject
 from zope.component import queryUtility
 from zope.event import notify
+from zope.lifecycleevent import Attributes
 from zope.lifecycleevent import ObjectModifiedEvent
 
 
@@ -184,7 +185,7 @@ class InstitutionIntegrationTest(PmPortalTestCase):
             container=self.portal, type="Institution", id="institution", website_url="https://old.example.be"
         )
         institution.website_url = "https://new.example.be"
-        notify(ObjectModifiedEvent(institution))
+        notify(ObjectModifiedEvent(institution, Attributes(IInstitution, "website_url")))
         self.assertEqual(institution.objectIds().count(WEBSITE_LINK_ID), 1)
         self.assertEqual(institution[WEBSITE_LINK_ID].remoteUrl, "https://new.example.be")
 
@@ -196,8 +197,19 @@ class InstitutionIntegrationTest(PmPortalTestCase):
         self.assertIn(WEBSITE_LINK_ID, institution.objectIds())
 
         institution.website_url = None
-        notify(ObjectModifiedEvent(institution))
+        notify(ObjectModifiedEvent(institution, Attributes(IInstitution, "website_url")))
         self.assertNotIn(WEBSITE_LINK_ID, institution.objectIds())
+
+    def test_unrelated_modification_leaves_link_untouched(self):
+        self.login_as_admin()
+        institution = api.content.create(
+            container=self.portal, type="Institution", id="institution", website_url="https://www.example.be"
+        )
+        link = institution[WEBSITE_LINK_ID]
+        link.remoteUrl = "https://untouched.example.be"
+        # a change that does not concern website_url must not re-sync the link
+        notify(ObjectModifiedEvent(institution, Attributes(IInstitution, "header_color")))
+        self.assertEqual(link.remoteUrl, "https://untouched.example.be")
 
     def test_ct_institution_modified(self):
         self.login_as_admin()

--- a/src/plonemeeting/portal/core/tests/test_institution.py
+++ b/src/plonemeeting/portal/core/tests/test_institution.py
@@ -37,6 +37,14 @@ class TestInstitutionView(PmPortalDemoFunctionalTestCase):
         self.assertEqual(view.request.response.status, 302)
         self.assertDictEqual(view.request.response.headers, {"location": "http://nohost/plone/belleville/decisions"})
 
+    def test_demo_institution_has_website_link(self):
+        belleville = self.portal["belleville"]
+        self.assertEqual(belleville.website_url, "https://www.belleville.be")
+        link = belleville["website-url"]
+        self.assertEqual(link.portal_type, "Link")
+        self.assertEqual(link.remoteUrl, "https://www.belleville.be")
+        self.assertEqual(api.content.get_state(link), "published")
+
     def test_validate_color_parameters(self):
         self.assertTrue(validate_color_parameters("#FFF"))
         self.assertTrue(validate_color_parameters("#00ab44"))
@@ -50,7 +58,7 @@ class TestInstitutionView(PmPortalDemoFunctionalTestCase):
         decisions_constraints = ISelectableConstrainTypes(self.institution.decisions)
         publications_constraints = ISelectableConstrainTypes(self.institution.publications)
         self.login_as_admin()
-        self.assertListEqual(["Folder"], institution_constraints.getLocallyAllowedTypes())
+        self.assertListEqual(["Folder", "Link"], institution_constraints.getLocallyAllowedTypes())
         self.assertListEqual(["Meeting"], decisions_constraints.getLocallyAllowedTypes())
         self.assertListEqual(["Publication"], publications_constraints.getLocallyAllowedTypes())
         self.login_as_test()

--- a/src/plonemeeting/portal/core/tests/test_utils.py
+++ b/src/plonemeeting/portal/core/tests/test_utils.py
@@ -307,7 +307,7 @@ class TestUtils(PmPortalDemoFunctionalTestCase):
     def test_set_constrain_types(self):
         constraints = ISelectableConstrainTypes(self.belleville)
         self.assertListEqual(
-            sorted(["Folder"]), sorted(constraints.getLocallyAllowedTypes())
+            sorted(["Folder", "Link"]), sorted(constraints.getLocallyAllowedTypes())
         )
         utils.set_constrain_types(self.belleville, [])
         self.assertListEqual([], constraints.getLocallyAllowedTypes())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Institutions can store a Website URL and automatically expose a corresponding published Website link.

* **Behavioral**
  * Institutions may contain Link children; clearing the Website URL removes the link. Upgrade restores link display in navigation.

* **Localization**
  * Added UI strings and French translations for "Website URL" and "Return to the institution website".

* **Demo**
  * Demo institutions include example website URLs.

* **Tests**
  * Added tests covering creation, update, reuse and removal of the website link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->