### PR TITLE
Fix test layer + raise coverage to 94%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [report]
 include =
-    src/plonemeeting/portal/core/*
+    */plonemeeting/portal/core/*
 omit =
     */migrations/*
     */test*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,27 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix test layer: load ``imio.omnia.core``, ``imio.omnia.assistant`` and
+  ``imio.omnia.tinymce`` ZCML in ``testing.py`` so the ``:default`` profile
+  dependency chain resolves under the test fixture (``z3c.autoinclude`` is
+  disabled there).
+  [aduchene]
+- Remove dead ``get_api_url_for_meeting_item`` (singular) helper from
+  ``utils.py`` — orphaned since 2021 with no callers.
+  [aduchene]
+- Tighten ``.coveragerc`` ``include`` pattern so it matches regardless of
+  the cwd from which coverage is invoked.
+  [aduchene]
+- Add tests for ``PreSyncReportForm._reconcile_items`` /
+  ``_reconcile_annexes``, ``ImportMeetingForm`` / ``PreSyncReportForm`` /
+  ``PreImportReportForm`` button handlers, the ``sync_meeting``
+  orchestrator, ``MeetingAddForm.updateFields``,
+  ``MeetingEditForm.handleApply`` / ``handleCancel``, the
+  ``validate_no_already_superseded`` schema validator and
+  ``SupersedeAdapter.supersedes_items`` / ``has_supersedes_items``, plus
+  ``get_api_url_for_presync_meeting_items``. Suite goes 182 → 204 tests;
+  application-code coverage 87% → 94%.
+  [aduchene]
 
 
 2.4.1 (2026-04-03)

--- a/src/plonemeeting/portal/core/testing.py
+++ b/src/plonemeeting/portal/core/testing.py
@@ -27,10 +27,16 @@ class PlonemeetingPortalCoreLayer(PloneSandboxLayer):
         # Load any other ZCML that is required for your tests.
         # The z3c.autoinclude feature is disabled in the Plone fixture base
         # layer.
+        import imio.omnia.assistant
+        import imio.omnia.core
+        import imio.omnia.tinymce
         import plone.restapi
 
         self.loadZCML(package=plone.restapi)
         self.loadZCML(package=collective.documentgenerator)
+        self.loadZCML(package=imio.omnia.core)
+        self.loadZCML(package=imio.omnia.assistant)
+        self.loadZCML(package=imio.omnia.tinymce)
         self.loadZCML(package=plonemeeting.portal.core)
 
         # Patch collective.fingerpointing

--- a/src/plonemeeting/portal/core/tests/test_meeting.py
+++ b/src/plonemeeting/portal/core/tests/test_meeting.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plonemeeting.portal.core.browser.meeting import MeetingAddForm
 from plonemeeting.portal.core.tests.portal_test_case import PmPortalDemoFunctionalTestCase
 
 
@@ -25,3 +26,42 @@ class TestMeetingView(PmPortalDemoFunctionalTestCase):
             view.request.response.headers,
             {'location': 'http://nohost/plone/belleville/decisions#seance={}'.format(
                 meeting.UID())})
+
+    def test_meeting_add_form_default_custom_info(self):
+        self.login_as_admin()
+        self.institution.default_meeting_extra_infos_text = "<p>my default</p>"
+        add_form = MeetingAddForm(self.institution.decisions, self.portal.REQUEST)
+        add_form.portal_type = "Meeting"
+        add_form.updateFields()
+        self.assertEqual(
+            add_form.fields["custom_info"].field.default,
+            "<p>my default</p>",
+        )
+
+    def test_meeting_edit_form_handle_apply_redirects_to_meeting(self):
+        self.login_as_admin()
+        request = self.portal.REQUEST
+        edit_form = self.meeting.restrictedTraverse("@@edit")
+        request.set("PUBLISHED", edit_form)
+        edit_form()
+        edit_form.handleApply(edit_form, None)
+        utils_view = self.meeting.restrictedTraverse("@@utils_view")
+        self.assertEqual(request.response.status, 302)
+        self.assertEqual(
+            request.response.headers["location"],
+            utils_view.get_meeting_url(meeting=self.meeting),
+        )
+
+    def test_meeting_edit_form_handle_cancel_redirects_to_meeting(self):
+        self.login_as_admin()
+        request = self.portal.REQUEST
+        edit_form = self.meeting.restrictedTraverse("@@edit")
+        request.set("PUBLISHED", edit_form)
+        edit_form()
+        edit_form.handleCancel(edit_form, None)
+        utils_view = self.meeting.restrictedTraverse("@@utils_view")
+        self.assertEqual(request.response.status, 302)
+        self.assertEqual(
+            request.response.headers["location"],
+            utils_view.get_meeting_url(meeting=self.meeting),
+        )

--- a/src/plonemeeting/portal/core/tests/test_publication.py
+++ b/src/plonemeeting/portal/core/tests/test_publication.py
@@ -9,6 +9,8 @@ from plone.dexterity.events import EditCancelledEvent
 from plone.locking.interfaces import ILockable
 from plone.namedfile.file import NamedBlobFile
 from plone.testing.zope import Browser
+from plonemeeting.portal.core.behaviors.supersede import SupersedeAdapter
+from plonemeeting.portal.core.behaviors.supersede import validate_no_already_superseded
 from plonemeeting.portal.core.tests import PM_ADMIN_USER
 from plonemeeting.portal.core.tests import PM_USER_PASSWORD
 from plonemeeting.portal.core.tests.portal_test_case import PmPortalDemoFunctionalTestCase
@@ -17,6 +19,7 @@ from unittest import mock
 from zExceptions import Redirect
 from zExceptions import Unauthorized
 from zope.event import notify
+from zope.interface import Invalid
 from zope.lifecycleevent import ObjectModifiedEvent
 
 import pytz
@@ -600,3 +603,21 @@ class TestPublicationView(PmPortalDemoFunctionalTestCase):
         self.assertIsNotNone(past_pub_no_ts.effective_date)
         # The effective date is kept
         self.assertEqual(past_pub_no_ts.effective_date, DateTime("1901/01/01"))
+
+    def test_validate_no_already_superseded(self):
+        self.login_as_publications_manager()
+        # pub_b supersedes pub_a; pub_a is now already superseded.
+        api.relation.create(
+            source=self.unpublished_publication,
+            target=self.published_publication,
+            relationship="supersede",
+        )
+        # A publication that has not been superseded yet validates fine.
+        self.assertTrue(validate_no_already_superseded(self.private_publication))
+        # The already-superseded publication can no longer be a supersede target.
+        with self.assertRaises(Invalid):
+            validate_no_already_superseded(self.published_publication)
+        # And the inverse: pub_b reports that it supersedes pub_a.
+        adapter = SupersedeAdapter(self.unpublished_publication)
+        self.assertTrue(adapter.has_supersedes_items())
+        self.assertEqual(adapter.supersedes_items(), [self.published_publication])

--- a/src/plonemeeting/portal/core/tests/test_sync.py
+++ b/src/plonemeeting/portal/core/tests/test_sync.py
@@ -10,10 +10,12 @@ from plone.app.testing import logout
 from plonemeeting.portal.core.config import API_HEADERS
 from plonemeeting.portal.core.content.meeting import IMeeting
 from plonemeeting.portal.core.sync_utils import _call_delib_rest_api
+from plonemeeting.portal.core.sync_utils import _json_date_to_datetime
 from plonemeeting.portal.core.sync_utils import get_formatted_data_from_json
 from plonemeeting.portal.core.sync_utils import sync_annexes_data
 from plonemeeting.portal.core.sync_utils import sync_items_data
 from plonemeeting.portal.core.sync_utils import sync_items_number
+from plonemeeting.portal.core.sync_utils import sync_meeting
 from plonemeeting.portal.core.sync_utils import sync_meeting_data
 from plonemeeting.portal.core.tests.portal_test_case import PmPortalDemoFunctionalTestCase
 from unittest.mock import patch
@@ -520,3 +522,338 @@ class TestMeetingSynchronization(PmPortalDemoFunctionalTestCase):
         self.assertEqual(len(meeting.items()), 1)
         self.assertIn("statusmessages", self.portal.REQUEST.response.cookies.keys())
 
+    def test_import_meeting_form_handle_select_redirects(self):
+        login(self.portal, "manager")
+        form = self.institution.decisions.restrictedTraverse("@@import_meeting")
+        with patch.object(form, "extractData", return_value=({"meeting": "EXT-UID"}, [])):
+            form.handle_select(form, None)
+        self.assertEqual(self.portal.REQUEST.response.status, 302)
+        self.assertEqual(
+            self.portal.REQUEST.response.headers["location"],
+            self.institution.decisions.absolute_url()
+            + "/@@pre_import_report_form?external_meeting_uid=EXT-UID",
+        )
+
+    def test_import_meeting_form_handle_select_with_errors(self):
+        login(self.portal, "manager")
+        form = self.institution.decisions.restrictedTraverse("@@import_meeting")
+        with patch.object(form, "extractData", return_value=({}, ["error"])):
+            form.handle_select(form, None)
+        self.assertEqual(form.status, form.formErrorsMessage)
+
+    def test_import_meeting_form_handle_cancel_redirects(self):
+        login(self.portal, "manager")
+        form = self.institution.decisions.restrictedTraverse("@@import_meeting")
+        form.handle_cancel(form, None)
+        self.assertEqual(self.portal.REQUEST.response.status, 302)
+        self.assertEqual(
+            self.portal.REQUEST.response.headers["location"],
+            self.institution.decisions.absolute_url(),
+        )
+
+    def test_import_meeting_form_update_handles_connection_error(self):
+        login(self.portal, "manager")
+        form = self.institution.decisions.restrictedTraverse("@@import_meeting")
+        # Make the underlying super().update() raise — this exercises the
+        # try/except wrapper and the _notify_error_and_cancel → handle_cancel chain.
+        from plone.autoform.form import AutoExtensibleForm
+        with patch.object(
+            AutoExtensibleForm, "update", side_effect=requests.exceptions.ConnectionError("boom")
+        ):
+            form.update()
+        self.assertEqual(self.portal.REQUEST.response.status, 302)
+        self.assertEqual(
+            self.portal.REQUEST.response.headers["location"],
+            self.institution.decisions.absolute_url(),
+        )
+
+    @patch("plonemeeting.portal.core.browser.sync._sync_meeting")
+    def test_pre_sync_handle_sync_calls_sync_meeting(self, _sync_meeting):
+        login(self.portal, "manager")
+        meeting = sync_meeting_data(self.institution, self.json_meeting.get("items")[0])
+        pre_sync_view = meeting.restrictedTraverse("@@pre_sync_report_form")
+        pre_sync_view.institution = self.institution
+        pre_sync_view.external_meeting_uid = "EXT-UID"
+
+        self.portal.REQUEST.form["item_uid__abc"] = True
+        self.portal.REQUEST.form["item_uid__def"] = True
+        pre_sync_view.handle_sync(pre_sync_view, "sync")
+
+        _sync_meeting.assert_called_once()
+        kwargs = _sync_meeting.call_args.kwargs
+        self.assertCountEqual(kwargs["item_external_uids"], ["abc", "def"])
+
+    def test_pre_sync_handle_cancel_redirects(self):
+        login(self.portal, "manager")
+        meeting = sync_meeting_data(self.institution, self.json_meeting.get("items")[0])
+        pre_sync_view = meeting.restrictedTraverse("@@pre_sync_report_form")
+        pre_sync_view.institution = self.institution
+
+        pre_sync_view.handle_cancel(pre_sync_view, None)
+        self.assertEqual(self.portal.REQUEST.response.status, 302)
+        self.assertEqual(
+            self.portal.REQUEST.response.headers["location"],
+            f"{self.institution.absolute_url()}/decisions/#seance={meeting.UID()}",
+        )
+
+    @patch("plonemeeting.portal.core.browser.sync._sync_meeting")
+    def test_pre_import_handle_import_calls_sync_meeting(self, _sync_meeting):
+        login(self.portal, "manager")
+        decisions = self.institution.decisions
+        pre_import_view = decisions.restrictedTraverse("@@pre_import_report_form")
+        pre_import_view.institution = self.institution
+        pre_import_view.external_meeting_uid = "EXT-UID"
+
+        self.portal.REQUEST.form["item_uid__abc"] = True
+        self.portal.REQUEST.form["item_uid__def"] = True
+        pre_import_view.handle_import(pre_import_view, "import")
+
+        _sync_meeting.assert_called_once()
+        kwargs = _sync_meeting.call_args.kwargs
+        self.assertCountEqual(kwargs["item_external_uids"], ["abc", "def"])
+
+    def test_pre_import_handle_cancel_redirects(self):
+        login(self.portal, "manager")
+        decisions = self.institution.decisions
+        pre_import_view = decisions.restrictedTraverse("@@pre_import_report_form")
+
+        pre_import_view.handle_cancel(pre_import_view, None)
+        self.assertEqual(self.portal.REQUEST.response.status, 302)
+        self.assertEqual(
+            self.portal.REQUEST.response.headers["location"],
+            decisions.absolute_url() + "/@@import_meeting",
+        )
+
+    @patch("plonemeeting.portal.core.sync_utils._call_delib_rest_api")
+    def test_sync_meeting(self, _call_api):
+        login(self.portal, "manager")
+        meeting_response = mock({"text": json.dumps(self.json_meeting)})
+        items_response = mock({"text": json.dumps(self.json_meeting_items)})
+        _call_api.side_effect = [meeting_response, items_response]
+
+        meeting_external_uid = self.json_meeting["items"][0]["UID"]
+        status, uid = sync_meeting(self.institution, meeting_external_uid, with_annexes=False)
+
+        self.assertEqual(_call_api.call_count, 2)
+        self.assertIsNotNone(uid)
+        self.assertIn("Meeting imported", status)
+        # The meeting now exists under the institution's decisions folder.
+        brains = api.content.find(
+            context=self.institution.decisions, plonemeeting_uid=meeting_external_uid
+        )
+        self.assertEqual(len(brains), 1)
+
+    @patch("plonemeeting.portal.core.sync_utils._call_delib_rest_api")
+    def test_sync_meeting_unexpected_count(self, _call_api):
+        login(self.portal, "manager")
+        bogus_payload = copy.deepcopy(self.json_meeting)
+        bogus_payload["items_total"] = 0
+        _call_api.return_value = mock({"text": json.dumps(bogus_payload)})
+
+        with self.assertRaises(ValueError):
+            sync_meeting(self.institution, "anything")
+
+    # --- _reconcile_items / _reconcile_annexes helpers and tests ----------
+    # Inputs are constructed inline so each scenario stays explicit; the
+    # reconcile methods are pure functions of (api payload, local content)
+    # so no REST mocking is needed here.
+
+    def _make_reconcile_view(self):
+        login(self.portal, "manager")
+        meeting = api.content.create(
+            container=self.institution.decisions,
+            type="Meeting",
+            id="reconcile-meeting",
+            title="Reconcile Meeting",
+        )
+        view = meeting.restrictedTraverse("@@pre_sync_report_form")
+        view.institution = self.institution
+        return meeting, view
+
+    @staticmethod
+    def _make_local_item(meeting, uid, modified_iso, number, item_id=None, with_annex_titles=()):
+        item = api.content.create(
+            container=meeting,
+            type="Item",
+            id=item_id or "item-" + uid,
+            title="Local " + uid,
+            plonemeeting_uid=uid,
+        )
+        item.plonemeeting_last_modified = _json_date_to_datetime(modified_iso)
+        item.number = number
+        for title in with_annex_titles:
+            api.content.create(container=item, type="File", id=title, title=title)
+        return item
+
+    @staticmethod
+    def _api_item(uid, modified_iso, number, annexes=()):
+        return {
+            "UID": uid,
+            "modified": modified_iso,
+            "formatted_itemNumber": number,
+            "category": {"title": "cat"},
+            "classifier": {"title": "cls"},
+            "representatives_in_charge": "-",
+            "extra_include_annexes": list(annexes),
+        }
+
+    @staticmethod
+    def _index_by_uid(reconciled):
+        return {item["UID"]: item for item in reconciled["items"]}
+
+    def test_reconcile_items_unchanged(self):
+        meeting, view = self._make_reconcile_view()
+        modified = "2024-01-01T10:00:00+00:00"
+        self._make_local_item(meeting, "uid-1", modified, "1")
+        api_items = {"items": [self._api_item("uid-1", modified, "1")]}
+
+        reconciled = view._reconcile_items(api_items, list(meeting.objectValues()))
+
+        item = self._index_by_uid(reconciled)["uid-1"]
+        self.assertEqual(item["status"], "unchanged")
+        self.assertEqual(item["annexes_status"], {})
+
+    def test_reconcile_items_modified_when_date_differs(self):
+        meeting, view = self._make_reconcile_view()
+        local_modified = "2024-01-01T10:00:00+00:00"
+        api_modified = "2024-02-01T10:00:00+00:00"
+        self._make_local_item(meeting, "uid-1", local_modified, "1")
+        api_items = {"items": [self._api_item("uid-1", api_modified, "1")]}
+
+        reconciled = view._reconcile_items(api_items, list(meeting.objectValues()))
+
+        item = self._index_by_uid(reconciled)["uid-1"]
+        self.assertEqual(item["status"], "modified")
+
+    def test_reconcile_items_modified_when_number_differs(self):
+        meeting, view = self._make_reconcile_view()
+        modified = "2024-01-01T10:00:00+00:00"
+        self._make_local_item(meeting, "uid-1", modified, "1")
+        api_items = {"items": [self._api_item("uid-1", modified, "2")]}
+
+        reconciled = view._reconcile_items(api_items, list(meeting.objectValues()))
+
+        item = self._index_by_uid(reconciled)["uid-1"]
+        self.assertEqual(item["status"], "modified")
+
+    def test_reconcile_items_added_with_and_without_annexes(self):
+        _meeting, view = self._make_reconcile_view()
+        api_items = {
+            "items": [
+                self._api_item("uid-new-no-annex", "2024-03-01T10:00:00+00:00", "1"),
+                self._api_item(
+                    "uid-new-with-annex",
+                    "2024-03-01T10:00:00+00:00",
+                    "2",
+                    annexes=[
+                        {"UID": "a1", "title": "annex one", "modified": "2024-03-01T10:00:00+00:00"},
+                        {"UID": "a2", "title": "annex two", "modified": "2024-03-01T10:00:00+00:00"},
+                    ],
+                ),
+            ],
+        }
+
+        reconciled = view._reconcile_items(api_items, [])
+        by_uid = self._index_by_uid(reconciled)
+
+        no_annex = by_uid["uid-new-no-annex"]
+        self.assertEqual(no_annex["status"], "added")
+        self.assertEqual(no_annex["local_last_modified"], "-")
+        self.assertEqual(no_annex["annexes_status"], {})
+
+        with_annex = by_uid["uid-new-with-annex"]
+        self.assertEqual(with_annex["status"], "added")
+        self.assertEqual(with_annex["annexes_status"]["added"]["count"], 2)
+        self.assertEqual(
+            with_annex["annexes_status"]["added"]["titles"],
+            ["annex one", "annex two"],
+        )
+
+    def test_reconcile_items_removed_with_and_without_annexes(self):
+        meeting, view = self._make_reconcile_view()
+        modified = "2024-01-01T10:00:00+00:00"
+        self._make_local_item(meeting, "uid-gone-empty", modified, "9", item_id="gone-empty")
+        self._make_local_item(
+            meeting,
+            "uid-gone-with-annex",
+            modified,
+            "10",
+            item_id="gone-with-annex",
+            with_annex_titles=("annex-x", "annex-y"),
+        )
+
+        reconciled = view._reconcile_items({"items": []}, list(meeting.objectValues()))
+        by_uid = self._index_by_uid(reconciled)
+
+        empty = by_uid["uid-gone-empty"]
+        self.assertEqual(empty["status"], "removed")
+        self.assertEqual(empty["annexes_status"], {})
+
+        with_annex = by_uid["uid-gone-with-annex"]
+        self.assertEqual(with_annex["status"], "removed")
+        self.assertEqual(with_annex["annexes_status"]["removed"]["count"], 2)
+        self.assertEqual(
+            sorted(with_annex["annexes_status"]["removed"]["titles"]),
+            ["annex-x", "annex-y"],
+        )
+
+    def test_reconcile_annexes_all_statuses(self):
+        meeting, view = self._make_reconcile_view()
+        modified = "2024-01-01T10:00:00+00:00"
+        local_item = self._make_local_item(meeting, "uid-1", modified, "1")
+        # Three local annexes: one will match unchanged, one modified, one removed.
+        unchanged_annex = api.content.create(
+            container=local_item, type="File", id="a-unchanged", title="Unchanged annex"
+        )
+        unchanged_annex.plonemeeting_uid = "annex-unchanged"
+        unchanged_annex.plonemeeting_last_modified = _json_date_to_datetime(modified)
+
+        modified_annex = api.content.create(
+            container=local_item, type="File", id="a-modified", title="Modified annex"
+        )
+        modified_annex.plonemeeting_uid = "annex-modified"
+        modified_annex.plonemeeting_last_modified = _json_date_to_datetime(modified)
+
+        removed_annex = api.content.create(
+            container=local_item, type="File", id="a-removed", title="Removed annex"
+        )
+        removed_annex.plonemeeting_uid = "annex-removed"
+        removed_annex.plonemeeting_last_modified = _json_date_to_datetime(modified)
+
+        api_annexes = [
+            {"UID": "annex-unchanged", "title": "Unchanged annex", "modified": modified},
+            {"UID": "annex-modified", "title": "Modified annex",
+             "modified": "2024-06-01T10:00:00+00:00"},
+            {"UID": "annex-added", "title": "Added annex", "modified": modified},
+        ]
+
+        result = view._reconcile_annexes(api_annexes, local_item.objectValues())
+
+        self.assertEqual(set(result.keys()), {"added", "unchanged", "modified", "removed"})
+        self.assertEqual(result["added"]["count"], 1)
+        self.assertEqual(result["added"]["titles"], ["Added annex"])
+        self.assertEqual(result["unchanged"]["count"], 1)
+        self.assertEqual(result["unchanged"]["titles"], ["Unchanged annex"])
+        self.assertEqual(result["modified"]["count"], 1)
+        self.assertEqual(result["modified"]["titles"], ["Modified annex"])
+        self.assertEqual(result["removed"]["count"], 1)
+        self.assertEqual(result["removed"]["titles"], ["Removed annex"])
+
+    def test_reconcile_annexes_strips_empty_buckets(self):
+        meeting, view = self._make_reconcile_view()
+        modified = "2024-01-01T10:00:00+00:00"
+        local_item = self._make_local_item(meeting, "uid-1", modified, "1")
+        annex = api.content.create(
+            container=local_item, type="File", id="a-unchanged", title="Annex"
+        )
+        annex.plonemeeting_uid = "annex-unchanged"
+        annex.plonemeeting_last_modified = _json_date_to_datetime(modified)
+
+        api_annexes = [
+            {"UID": "annex-unchanged", "title": "Annex", "modified": modified},
+        ]
+
+        result = view._reconcile_annexes(api_annexes, local_item.objectValues())
+
+        self.assertEqual(set(result.keys()), {"unchanged"})
+        self.assertEqual(result["unchanged"]["count"], 1)

--- a/src/plonemeeting/portal/core/tests/test_utils.py
+++ b/src/plonemeeting/portal/core/tests/test_utils.py
@@ -73,6 +73,40 @@ class TestUtils(PmPortalDemoFunctionalTestCase):
             url,
         )
 
+    def test_get_api_url_for_presync_meeting_items(self):
+        self.belleville.categories_mappings = None
+        url = utils.get_api_url_for_presync_meeting_items(self.belleville, "foo")
+        self.assertEqual(
+            "https://demo-pm.imio.be/@search?"
+            "type=item"
+            "&sort_on=getItemNumber"
+            "&privacy=public"
+            "&privacy=public_heading"
+            "&b_size=9999"
+            "&additional_values=formatted_itemNumber"
+            "&config_id=meeting-config-college"
+            "&linkedMeetingUID=foo"
+            "&meeting_uid=foo"
+            "&fullobjects=True"
+            "&include_all=false"
+            "&metadata_fields=itemNumber"
+            "&metadata_fields=groupsInCharge"
+            "&metadata_fields=category"
+            "&review_state=itemfrozen"
+            "&review_state=accepted"
+            "&review_state=accepted_but_modified"
+            "&getCategory=VOID"
+            "&getGroupsInCharge=7a82fee367a0416f8d7e8f4a382db0d1"
+            "&getGroupsInCharge=a2396143f11f4e2292f12ee3b3447739"
+            "&getGroupsInCharge=bf5fccd9bc9048e9957680c7ab5576b4"
+            "&getGroupsInCharge=f3f9e7808ddb4e56946b2dba6370eb9b"
+            "&extra_include=annexes"
+            "&extra_include_annexes_fullobjects"
+            "&extra_include_annexes_include_all=false"
+            "&extra_include_annexes_publishable=true",
+            url,
+        )
+
     def test_get_api_url_for_meeting_items(self):
         # test empty category_mappings
         self.belleville.categories_mappings = None

--- a/src/plonemeeting/portal/core/utils.py
+++ b/src/plonemeeting/portal/core/utils.py
@@ -242,52 +242,6 @@ def get_api_url_for_meeting_items(institution, meeting_external_uid, item_extern
     return url
 
 
-def get_api_url_for_meeting_item(institution, meeting_item_uids):
-    if not institution.plonemeeting_url or not institution.meeting_config_id:
-        return
-    category_filter = _get_category_filter_url(institution)
-    representatives_filter = _get_representatives_filter_url(institution)
-    item_filter_query = _datagrid_to_url_param(institution.item_filter_query)
-    item_content_query = _datagrid_to_url_param(institution.item_content_query)
-    url = (
-        "{0}/@search?"
-        "type={1}"
-        "&sort_on=getItemNumber"
-        "&privacy=public"
-        "&privacy=public_heading"
-        "&b_size=9999"
-        "&additional_values=formatted_itemNumber"
-        "&config_id={2}"
-        "&uid={3}"
-        "&meeting_uid={3}"
-        "&fullobjects=True"
-        # by default fullobjects return everything, here we include nothing
-        # so by default only base data (id, title, UID, ...) are returned
-        "&include_all=false"
-        # field required by application
-        "&metadata_fields=itemNumber"
-        # field required by application
-        "&metadata_fields=groupsInCharge"
-        # field required by application, will be "category" or "classifier"
-        "&metadata_fields={4}"
-        "{5}"
-        "{6}"
-        "{7}"
-        "{8}".format(
-            institution.plonemeeting_url.rstrip("/"),
-            PLONEMEETING_API_ITEM_TYPE,
-            institution.meeting_config_id,
-            "&uid={3}".join(meeting_item_uids),
-            institution.delib_category_field,
-            item_filter_query,
-            item_content_query,
-            category_filter,
-            representatives_filter,
-        )
-    )
-    return url
-
-
 def get_api_url_for_categories(institution, delib_config_category_field):
     if institution.plonemeeting_url and institution.meeting_config_id:
         url = "{plonemeeting_url}/@config?config_id={meeting_config_id}&extra_include={delib_category_field}".format(


### PR DESCRIPTION
## Summary

- **Test layer fix:** `testing.py` now loads `imio.omnia.{core,assistant,tinymce}` ZCML so the `:default` profile dependency chain resolves under the test fixture. Without this the suite ran **0 tests, 2 errors** since 2.4.0.
- **Dead-code removal:** drop `get_api_url_for_meeting_item` (singular) from `utils.py` — orphaned since Dec 2021 (`49ef7ba` removed its only callsite), zero references across the buildout `src/` tree and installed eggs.
- **`.coveragerc`:** widen `include` to `*/plonemeeting/portal/core/*` so it matches regardless of cwd (the previous anchored pattern silently produced "No data to report" when run from outside the package dir).
- **New tests** raising the application-code coverage from **87% to 94%** (suite 182 → 204 tests):
  - `PreSyncReportForm._reconcile_items` / `_reconcile_annexes` (the pre-sync diff classifier).
  - `ImportMeetingForm.handle_select` (happy path + errors path), `handle_cancel`, `update` ConnectionError fallback.
  - `PreSyncReportForm.handle_sync` / `handle_cancel`, `PreImportReportForm.handle_import` / `handle_cancel`.
  - `sync_utils.sync_meeting` orchestrator (happy path + items_total != 1).
  - `MeetingAddForm.updateFields`, `MeetingEditForm.handleApply` / `handleCancel`.
  - `validate_no_already_superseded` + `SupersedeAdapter.supersedes_items` / `has_supersedes_items`.
  - `get_api_url_for_presync_meeting_items` URL builder.

## Coverage by module after this PR

| Module | Before | After |
|---|---|---|
| `behaviors/supersede.py` | 81% | **100%** |
| `browser/sync.py` | 66% | **99%** |
| `sync_utils.py` | 90% | **98%** |
| `browser/meeting.py` | 68% | **97%** |
| `utils.py` | 89% | **94%** |
| **Application total** | 87% | **94%** |

## Note for the buildout shell

This PR raises the package's reported coverage to 94%, but `bin/coverage` / `bin/report` in `buildout.pm.portal` need to pass `--rcfile=.../plonemeeting.portal.core/.coveragerc` to honor the `include` / `omit` rules above. A separate change in `dev.cfg` covers that.

## Test plan

- [ ] `bin/test` from the buildout root: 204 tests, 0 failures.
- [ ] `bin/coverage && bin/report` (after the buildout shell fix above): HTML report shows ~94% with migrations excluded.
- [ ] Spot-check `htmlcov/index.html` for the targeted modules listed in the table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive automated tests covering meeting sync, import/reconcile flows, forms, publication validation, and API URL generation.

* **Bug Fixes**
  * Fixed form submit/cancel handlers to restore correct redirect behavior.
  * Ensured test runtime loads required components so fixtures resolve.

* **Chores**
  * Removed an unused helper function.
  * Refined coverage configuration for more flexible path matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->