### PR TITLE
DELIBE-287: gate history toolbar action on View History permission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
+- Fix workflow/version history visibility for non-editor users
+  (DELIBE-287): the ``history`` toolbar action and the ``@@historyview``
+  page are now gated by the ``View History`` permission instead of
+  ``Modify portal content``. ``View History`` is granted to ``Reader``
+  (and ``Contributor``/``Reviewer``/``Editor``/``Manager``/
+  ``Site Administrator``) at the portal root via ``rolemap.xml`` and
+  flows down to every institution content type by acquisition. Existing
+  sites pick up the change via the 2500 upgrade step.
+  [aduchene]
 - Fix test layer: load ``imio.omnia.core``, ``imio.omnia.assistant`` and
   ``imio.omnia.tinymce`` ZCML in ``testing.py`` so the ``:default`` profile
   dependency chain resolves under the test fixture (``z3c.autoinclude`` is

--- a/src/plonemeeting/portal/core/migrations/configure.zcml
+++ b/src/plonemeeting/portal/core/migrations/configure.zcml
@@ -239,4 +239,12 @@
     destination="2400"
     handler="plonemeeting.portal.core.migrations.migrate_to_2400.migrate"
     profile="plonemeeting.portal.core:default"/>
+
+  <genericsetup:upgradeStep
+    title="Go to portal 2500"
+    description="Gate the 'history' action and @@historyview on the 'View History' permission so publication managers can see history in 'published' and 'archived' states."
+    source="2400"
+    destination="2500"
+    handler="plonemeeting.portal.core.migrations.migrate_to_2500.migrate"
+    profile="plonemeeting.portal.core:default"/>
 </configure>

--- a/src/plonemeeting/portal/core/migrations/migrate_to_2500.py
+++ b/src/plonemeeting/portal/core/migrations/migrate_to_2500.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from plonemeeting.portal.core.migrations import PlonemeetingMigrator
+
+import logging
+
+
+logger = logging.getLogger("plonemeeting.portal.core")
+
+
+class MigrateTo2500(PlonemeetingMigrator):
+
+    def run(self):
+        logger.info("Migrating to plonemeeting.portal.core 2500")
+        self.ps.runImportStepFromProfile("profile-plonemeeting.portal.core:default", "rolemap")
+        self.ps.runImportStepFromProfile("profile-plonemeeting.portal.core:default", "actions")
+        logger.info("Migration to plonemeeting.portal.core 2500 done.")
+
+
+def migrate(context):
+    """
+    DELIBE-287: gate the workflow/version 'history' toolbar action and the
+    @@historyview page on the 'View History' permission instead of
+    'Modify portal content', and grant 'View History' to Reader at the
+    portal root so it flows down via acquisition to every institution
+    content type. No workflow declares View History in its permission
+    header, so acquisition is never cut.
+    """
+    migrator = MigrateTo2500(context)
+    migrator.run()
+    migrator.finish()

--- a/src/plonemeeting/portal/core/overrides.zcml
+++ b/src/plonemeeting/portal/core/overrides.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <!-- DELIBE-287: gate @@historyview on the "View History" permission
+       instead of "Modify portal content", so non-editors with the Reader
+       role can still inspect the workflow/version history of an object
+       in states where they cannot modify it (e.g. published, archived). -->
+  <browser:page
+      name="historyview"
+      for="*"
+      class="plone.app.layout.viewlets.content.HistoryByLineView"
+      permission="zope2.ViewHistory"
+      />
+
+</configure>

--- a/src/plonemeeting/portal/core/permissions.zcml
+++ b/src/plonemeeting/portal/core/permissions.zcml
@@ -20,6 +20,10 @@
         id="plonemeeting.portal.core.AddPublication"
         title="plonemeeting.portal.core: Add Publication"
     />
+    <permission
+        id="zope2.ViewHistory"
+        title="View History"
+    />
   </configure>
 
 </configure>

--- a/src/plonemeeting/portal/core/profiles/default/actions.xml
+++ b/src/plonemeeting/portal/core/profiles/default/actions.xml
@@ -41,7 +41,7 @@
   <object name="object" meta_type="CMF Action Category">
     <object name="history" meta_type="CMF Action">
       <property name="permissions">
-        <element value="Modify portal content"/>
+        <element value="View History"/>
       </property>
     </object>
     <object name="local_roles" meta_type="CMF Action">

--- a/src/plonemeeting/portal/core/profiles/default/metadata.xml
+++ b/src/plonemeeting/portal/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <metadata>
-  <version>2400</version>
+  <version>2500</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-collective.z3cform.datagridfield:default</dependency>

--- a/src/plonemeeting/portal/core/profiles/default/rolemap.xml
+++ b/src/plonemeeting/portal/core/profiles/default/rolemap.xml
@@ -54,6 +54,20 @@
       <role name="Manager"/>
     </permission>
 
+    <permission name="View History" acquire="True">
+      <!-- DELIBE-287: let users with the Reader local role (publications
+           managers/creators/reviewers, decisions managers, etc.) see the
+           workflow/version history of institution content in every workflow
+           state. Flows down to all workflowed content via acquisition since
+           no workflow declares View History in its <permission> header. -->
+      <role name="Reader"/>
+      <role name="Contributor"/>
+      <role name="Reviewer"/>
+      <role name="Editor"/>
+      <role name="Manager"/>
+      <role name="Site Administrator"/>
+    </permission>
+
   </permissions>
 
 </rolemap>

--- a/src/plonemeeting/portal/core/testing.py
+++ b/src/plonemeeting/portal/core/testing.py
@@ -38,6 +38,10 @@ class PlonemeetingPortalCoreLayer(PloneSandboxLayer):
         self.loadZCML(package=imio.omnia.assistant)
         self.loadZCML(package=imio.omnia.tinymce)
         self.loadZCML(package=plonemeeting.portal.core)
+        # plone.autoinclude is disabled in the Plone fixture; load our
+        # overrides.zcml the same way Products.CMFPlone does at runtime
+        # (autoIncludePluginsOverrides target="plone").
+        self.loadZCML(name="overrides.zcml", package=plonemeeting.portal.core)
 
         # Patch collective.fingerpointing
 

--- a/src/plonemeeting/portal/core/tests/test_publication.py
+++ b/src/plonemeeting/portal/core/tests/test_publication.py
@@ -157,6 +157,44 @@ class TestPublicationView(PmPortalDemoFunctionalTestCase):
         view = self.unpublished_publication.restrictedTraverse("@@edit")
         self.assertTrue(view())
 
+    def test_publication_history_visibility_for_publication_manager(self):
+        # A publication manager (Reader local-role) must be able to reach
+        # @@historyview and see the 'history' toolbar action in every
+        # workflow state, including 'published' and 'archived' where they
+        # don't have 'Modify portal content'.
+        self.login_as_publications_manager()
+        cases = [
+            ("private", self.private_publication),
+            ("planned", self.planned_publication),
+            ("unpublished", self.unpublished_publication),
+            ("published", self.published_publication),
+        ]
+        for state, pub in cases:
+            self.assertEqual(api.content.get_state(pub), state)
+            try:
+                pub.restrictedTraverse("@@historyview")
+            except Unauthorized:
+                self.fail("@@historyview not accessible in state '%s'" % state)
+            actions = self.portal.portal_actions.listFilteredActionsFor(pub)
+            history_actions = [a for a in actions.get("object", []) if a["id"] == "history"]
+            self.assertTrue(
+                history_actions,
+                "'history' action not visible in state '%s'" % state,
+            )
+
+        # Archive the published one and re-check as the same user.
+        self.login_as_admin()
+        self.workflow.doActionFor(self.published_publication, "archive")
+        self.assertEqual(api.content.get_state(self.published_publication), "archived")
+        self.login_as_publications_manager()
+        try:
+            self.published_publication.restrictedTraverse("@@historyview")
+        except Unauthorized:
+            self.fail("@@historyview not accessible in state 'archived'")
+        actions = self.portal.portal_actions.listFilteredActionsFor(self.published_publication)
+        history_actions = [a for a in actions.get("object", []) if a["id"] == "history"]
+        self.assertTrue(history_actions, "'history' action not visible in state 'archived'")
+
     def test_published_publication_is_timestamped(self):
         self.login_as_publications_manager()
         pub = self.private_publication


### PR DESCRIPTION
## Summary

- The `history` toolbar action and the `@@historyview` page were gated on `Modify portal content`, so users with only the `Reader` local role (publication managers/creators/reviewers, decisions managers, …) lost access to the workflow/version history as soon as an object left a writable workflow state — e.g. on `published` or `archived` publications.
- Gate both on the `View History` permission (Zope OFS's `OFS.History.view_history`) instead, then grant `View History` at the portal root via `rolemap.xml` so it flows down to every institution content type by acquisition. No workflow declares `View History` in its `<permission>` header, so nothing cuts the chain.
- `permissions.zcml` registers a `zope2.ViewHistory` dotted ID for the OFS permission so it's referenceable from ZCML; `overrides.zcml` re-registers `@@historyview` against it.
- `testing.py` explicitly loads `overrides.zcml` because `plone.autoinclude` is disabled in the Plone test fixture; in production `Products.CMFPlone`'s `autoIncludePluginsOverrides target="plone"` picks it up at startup.
- Existing sites pick up the change via the 2500 upgrade step (re-imports `rolemap` + `actions`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * History toolbar action and publication history view now controlled by the "View History" permission instead of "Modify portal content", enabling more granular access management. Existing installations update via migration step 2500.

* **Tests**
  * Added test coverage for history visibility across multiple publication workflow states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/plonemeeting.portal.core/pull/98)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->