### PR TITLE
DELIBE-312: Fix an issue when an anonymous user was trying to access a private decision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 2.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- DELIBE-312: Fix an issue when an anonymous user was trying to access a private decision.
+  Add a new comprehensive unit test `test_anonymous_unauthorized_item_view`.
+  [aduchene]
 
 2.4.3 (2026-06-15)
 ------------------
@@ -13,57 +14,48 @@ Changelog
 - Fix typo.
   [aduchene]
 
-
 2.4.2 (2026-06-15)
 ------------------
 
-- Send the ``Last-Modified`` header again on the ``@@custom_colors.css``
+- DELIBE-306: Send the ``Last-Modified`` header again on the ``@@custom_colors.css``
   view, so browsers refresh the CSS when an institution changes its colors.
-  [DELIBE-306]
   [aduchene]
-
-- Add Plausible web statistics dashboards: a ``@@statistics`` view on each
+- DELIBE-307: Add Plausible web statistics dashboards: a ``@@statistics`` view on each
   institution and a global control panel. The dashboard is shown in an
   iframe; the Plausible site and its shared link are created (or refreshed)
   on each visit, so the dashboard keeps working even if the link is deleted
   or changed on the Plausible side. The Plausible URL, API key and site
   domain are set in the registry, and a clear message is shown when Plausible
-  is not reachable. [DELIBE-307]
+  is not reachable.
   [aduchene]
-
-- Add RSS/Atom feeds of the latest decisions and publications. Feeds are
+- DELIBE-255: Add RSS/Atom feeds of the latest decisions and publications. Feeds are
   available on the usual Plone URLs, e.g.
   ``/<institution>/publications/rss.xml``, and list the most recent
   published items first. An upgrade step turns them on for existing
-  institutions. [DELIBE-255]
+  institutions.
   [aduchene]
-
-- Add a "Remove expiration date" action on publications, for publications
+- DELIBE-305: Add a "Remove expiration date" action on publications, for publications
   managers and site administrators. It clears the expiration date while
   keeping the qualified timestamp. Also improve the help text of the
-  expiration date field. [DELIBE-305]
+  expiration date field.
   [aduchene]
-
 - Drop support for Python 3.11; require Python >= 3.12 (``python_requires``,
   classifiers and Ruff ``target-version`` updated accordingly).
   [aduchene]
-
-- Adopt Ruff for Python linting/formatting (``pyproject.toml`` ``[tool.ruff]``,
+- DELIBE-291: Adopt Ruff for Python linting/formatting (``pyproject.toml`` ``[tool.ruff]``,
   ``line-length = 120``) and ``zpretty`` for templates/ZCML/XML; drop the old
   ``.flake8`` / ``.isort.cfg`` / ``setup.cfg``. Run on demand via ``make lint``
   (``ruff check``) and ``make format`` (``ruff`` + ``zpretty``) — no pre-commit,
   tox or CI. The codebase is intentionally not reformatted here; run
-  ``make format`` to apply it as a dedicated change. [DELIBE-291]
+  ``make format`` to apply it as a dedicated change.
   [aduchene]
-
-- Add a configurable ``website_url`` field on ``Institution`` that keeps a
+- DELIBE-112: Add a configurable ``website_url`` field on ``Institution`` that keeps a
   published ``Link`` (``website-url``) to the communal website in sync. The
   link is managed from the add/modify event subscribers
   (``sync_website_link``) instead of a property setter, so it no longer
   crashes when the field is set before the institution is added to the
-  portal, and clearing the URL removes the link. [DELIBE-112]
+  portal, and clearing the URL removes the link.
   [aduchene]
-
 - Fix test layer: load ``imio.omnia.core``, ``imio.omnia.assistant`` and
   ``imio.omnia.tinymce`` ZCML in ``testing.py`` so the ``:default`` profile
   dependency chain resolves under the test fixture (``z3c.autoinclude`` is
@@ -86,13 +78,11 @@ Changelog
   application-code coverage 87% → 94%.
   [aduchene]
 
-
 2.4.1 (2026-04-03)
 ------------------
 
 - Enable AI assistant on ``Item`` (Decision) content type in addition to ``Publication``.
   [aduchene]
-
 
 2.4.0 (2026-04-03)
 ------------------
@@ -113,7 +103,6 @@ Changelog
 - Add upgrade step to 2400: installs the three omnia add-ons and re-imports ``typeinfo``
   and ``rolemap``.
   [aduchene]
-
 
 2.3.2 (2026-01-28)
 ------------------

--- a/src/plonemeeting/portal/core/browser/item.py
+++ b/src/plonemeeting/portal/core/browser/item.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from plone import api
 from plone.dexterity.browser.view import DefaultView
-from plonemeeting.portal.core.browser import BaseAddForm
 from plonemeeting.portal.core.browser import BaseEditForm
 from plonemeeting.portal.core.browser.nextprevious import NextPrevItemNumber
-from plonemeeting.portal.core.cache import item_meeting_modified_cachekey
+from plonemeeting.portal.core.cache import meeting_modified_cachekey
+from plonemeeting.portal.core.cache import item_next_prev_infos_cachekey
 from plone.memoize import ram
 
 
@@ -27,7 +27,7 @@ class ItemView(DefaultView):
         """
         return self.context.aq_parent
 
-    @ram.cache(item_meeting_modified_cachekey)
+    @ram.cache(item_next_prev_infos_cachekey)
     def get_next_prev_infos(self):
         """
         Get the previous and next items in the meeting. This is based on Plone's
@@ -46,7 +46,7 @@ class ItemView(DefaultView):
             res.update({"previous_item": {}, "next_item": {}})
         return res
 
-    @ram.cache(item_meeting_modified_cachekey)
+    @ram.cache(meeting_modified_cachekey)
     def get_last_item_number(self):
         items = self.get_meeting().get_items(objects=False)
         # We need to be careful here, user might be an anonymous loading the page

--- a/src/plonemeeting/portal/core/browser/item.py
+++ b/src/plonemeeting/portal/core/browser/item.py
@@ -4,6 +4,8 @@ from plone.dexterity.browser.view import DefaultView
 from plonemeeting.portal.core.browser import BaseAddForm
 from plonemeeting.portal.core.browser import BaseEditForm
 from plonemeeting.portal.core.browser.nextprevious import NextPrevItemNumber
+from plonemeeting.portal.core.cache import item_meeting_modified_cachekey
+from plone.memoize import ram
 
 
 class ItemForm:
@@ -25,7 +27,7 @@ class ItemView(DefaultView):
         """
         return self.context.aq_parent
 
-    # @ram.cache(item_meeting_modified_cachekey)
+    @ram.cache(item_meeting_modified_cachekey)
     def get_next_prev_infos(self):
         """
         Get the previous and next items in the meeting. This is based on Plone's
@@ -44,9 +46,12 @@ class ItemView(DefaultView):
             res.update({"previous_item": {}, "next_item": {}})
         return res
 
-    # @ram.cache(item_meeting_modified_cachekey)
+    @ram.cache(item_meeting_modified_cachekey)
     def get_last_item_number(self):
-        return self.get_meeting().get_items(objects=False)[-1].number
+        items = self.get_meeting().get_items(objects=False)
+        # We need to be careful here, user might be an anonymous loading the page
+        # and get_items() will return an empty list
+        return items[-1].number if len(items) > 0 else None
 
     def show_project_decision_disclaimer(self):
         """ """

--- a/src/plonemeeting/portal/core/cache.py
+++ b/src/plonemeeting/portal/core/cache.py
@@ -10,8 +10,15 @@ def published_institutions_modified_cachekey(method, self):
                               sort_on='getId')
     return [brain.id + "_" + str(brain.modified) for brain in brains]
 
-def item_meeting_modified_cachekey(method, self):
+def meeting_modified_cachekey(method, self):
     """
     Cache key based of item's meeting modification date
     """
-    return self.get_meeting().modified
+    return str(self.get_meeting().modified)
+
+def item_next_prev_infos_cachekey(method, self):
+    """
+    Cache key for an item's next/previous infos. The result depends on the item being viewed,
+    so the item id must be part of the key.
+    """
+    return self.context.getId() + "_" + str(self.get_meeting().modified)

--- a/src/plonemeeting/portal/core/tests/test_item.py
+++ b/src/plonemeeting/portal/core/tests/test_item.py
@@ -60,6 +60,7 @@ class TestItemView(PmPortalDemoFunctionalTestCase):
         self.assertTrue(view())
         with self.assertRaises(Unauthorized):
             self.item.restrictedTraverse("@@view")
+        with self.assertRaises(Unauthorized):
             self.item.restrictedTraverse("@@edit")
 
     def test_next_previous_infos_items_view(self):

--- a/src/plonemeeting/portal/core/tests/test_item.py
+++ b/src/plonemeeting/portal/core/tests/test_item.py
@@ -59,7 +59,9 @@ class TestItemView(PmPortalDemoFunctionalTestCase):
         view = self.item.restrictedTraverse("@@view")
         self.assertTrue(view())
         with self.assertRaises(Unauthorized):
-            self.item.restrictedTraverse("@@view")
+            # Weird hack to force traversal on meeting
+            # since it's holding the private state/perms
+            self.item.aq_parent.restrictedTraverse(self.item.getId())
         with self.assertRaises(Unauthorized):
             self.item.restrictedTraverse("@@edit")
 

--- a/src/plonemeeting/portal/core/tests/test_item.py
+++ b/src/plonemeeting/portal/core/tests/test_item.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from imio.helpers.content import richtextval
 from plone import api
+from plone.app.testing import logout
 from plonemeeting.portal.core.config import MIMETYPE_TO_ICON
 from plonemeeting.portal.core.content.item import get_pretty_representatives
 from plonemeeting.portal.core.tests.portal_test_case import IMG_BASE64_DATA
 from plonemeeting.portal.core.tests.portal_test_case import PmPortalDemoFunctionalTestCase
+from zExceptions import Unauthorized
 
 
 class TestItemView(PmPortalDemoFunctionalTestCase):
@@ -31,6 +33,34 @@ class TestItemView(PmPortalDemoFunctionalTestCase):
         self.assertTrue(view())
         # project disclaimer message displayed
         self.assertTrue("alert-content" in view())
+
+    def test_anonymous_unauthorized_item_view(self):
+        # decision, should be viewable to anonymous
+        self.assertEqual(api.content.get_state(self.meeting), "decision")
+        logout()
+        view = self.item.restrictedTraverse("@@view")
+        self.assertTrue(view())
+        with self.assertRaises(Unauthorized):
+            self.item.restrictedTraverse("@@edit")
+
+        # in_project, should be still viewable to anonymous
+        self.login_as_admin()
+        api.content.transition(self.meeting, to_state="in_project")
+        logout()
+        view = self.item.restrictedTraverse("@@view")
+        self.assertTrue(view())
+        with self.assertRaises(Unauthorized):
+            self.item.restrictedTraverse("@@edit")
+
+        # private, shouldn't be viewable to anonymous but the view shouldn't fail
+        self.login_as_admin()
+        api.content.transition(self.meeting, to_state="private")
+        logout()
+        view = self.item.restrictedTraverse("@@view")
+        self.assertTrue(view())
+        with self.assertRaises(Unauthorized):
+            self.item.restrictedTraverse("@@view")
+            self.item.restrictedTraverse("@@edit")
 
     def test_next_previous_infos_items_view(self):
         self.logout()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed anonymous access for private decision items, ensuring correct permissions for viewing vs editing across meeting workflow states
  * Improved robustness when meetings have no items, preventing incorrect “last item” lookups

* **Performance**
  * Added memoization for item next/previous navigation data and last-item number computations

* **Tests & Documentation**
  * Added a unit test covering anonymous unauthorized access scenarios
  * Updated the changelog for 2.4.4 (unreleased) and reformatted prior entries for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->