### PR TITLE
DELIBE-318: Store meeting_type on the Meeting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 2.4.4 (unreleased)
 ------------------
 
+- DELIBE-318: Store the ``meeting_type`` on each meeting instead of reading it
+  from the institution. The value is copied from the institution at import time,
+  views read it from the meeting (falling back to the institution), and an
+  upgrade step backfills existing meetings. First step toward decoupling the
+  iA.Délib configuration.
+  [aduchene]
 - DELIBE-285: Add a "Duplicate" publication action that opens the add form
   pre-filled from the original (except timestamps and publication dates) and
   sets the new publication to supersede the original.

--- a/src/plonemeeting/portal/core/browser/templates/item.pt
+++ b/src/plonemeeting/portal/core/browser/templates/item.pt
@@ -107,7 +107,7 @@
                 </i>
               </div>
               <div class="meeting-infos">
-                <div class="meeting-type" i18n:translate="" tal:content="utils_view/meeting_type">Public meeting</div>
+                <div class="meeting-type" i18n:translate="" tal:content="python:utils_view.meeting_type(meeting)">Public meeting</div>
                 <span href="" class="meeting-title"
                    tal:content="meeting/title"
                 >

--- a/src/plonemeeting/portal/core/browser/utils.py
+++ b/src/plonemeeting/portal/core/browser/utils.py
@@ -7,6 +7,7 @@ from plone.protect.utils import addTokenToUrl
 from plonemeeting.portal.core import _
 from plonemeeting.portal.core.config import MIMETYPE_TO_ICON
 from plonemeeting.portal.core.content.institution import IInstitution
+from plonemeeting.portal.core.content.item import IItem
 from plonemeeting.portal.core.content.meeting import IMeeting
 from plonemeeting.portal.core.interfaces import IMeetingsFolder
 from plonemeeting.portal.core.interfaces import IPublicationsFolder
@@ -124,7 +125,20 @@ class UtilsView(BrowserView):
     def protect_url(self, url):
         return addTokenToUrl(url)
 
-    def meeting_type(self):
+    def get_current_meeting(self):
+        """Resolve the meeting the current context relates to, or None."""
+        if self.is_meeting():
+            return self.context
+        if IItem.providedBy(self.context):
+            return self.context.aq_parent
+        return self.get_linked_meeting()
+
+    def meeting_type(self, meeting=None):
+        """Meeting type label, read from the meeting, falling back to the institution."""
+        if meeting is None:
+            meeting = self.get_current_meeting()
+        if meeting is not None and getattr(meeting, "meeting_type", None):
+            return get_term_title(meeting, "meeting_type")
         return get_term_title(self.get_current_institution(), "meeting_type")
 
     def institution_type(self):

--- a/src/plonemeeting/portal/core/content/meeting.py
+++ b/src/plonemeeting/portal/core/content/meeting.py
@@ -37,6 +37,14 @@ class IMeeting(model.Schema):
 
     plonemeeting_last_modified = schema.Datetime(title=_("Last modification in iA.Delib"), required=True, readonly=True)
 
+    model.fieldset("settings", fields=["meeting_type"])
+    meeting_type = schema.Choice(
+        title=_("Meeting Type"),
+        vocabulary="plonemeeting.portal.vocabularies.meeting_types",
+        required=True,
+        default="council",
+    )
+
 
 @implementer(IMeeting)
 class Meeting(Container):

--- a/src/plonemeeting/portal/core/faceted/preview_meeting.pt
+++ b/src/plonemeeting/portal/core/faceted/preview_meeting.pt
@@ -19,7 +19,7 @@
                 checkPermission nocall: context/portal_membership/checkPermission;
                 utils_view nocall:context/@@utils_view;
                 meeting python: utils_view.get_linked_meeting();
-                meeting_type context/@@utils_view/meeting_type;
+                meeting_type python:utils_view.meeting_type(meeting);
       ">
       <div class="pm-preview-meeting">
         <tal:meeting define="utils_view nocall:context/@@utils_view;
@@ -114,7 +114,7 @@
 
         <span tal:condition="folderContents" class="faceted-container">
             <tal:entries tal:define="preview nocall:context/@@faceted-macro-pm-item/preview_meeting_item;
-              meeting_type context/@@utils_view/meeting_type">
+              meeting_type python:utils_view.meeting_type(meeting)">
               <tal:entry repeat="brain batch">
                 <metal:macro use-macro="preview"
                    tal:define="brain nocall:brain;

--- a/src/plonemeeting/portal/core/migrations/configure.zcml
+++ b/src/plonemeeting/portal/core/migrations/configure.zcml
@@ -304,4 +304,12 @@
     run_deps="False"
     profile="plonemeeting.portal.core:default"/>
 
+  <genericsetup:upgradeStep
+    title="Store meeting_type on existing meetings"
+    description="Backfill the new Meeting.meeting_type field from each meeting's institution."
+    source="2405"
+    destination="2406"
+    handler="plonemeeting.portal.core.migrations.migrate_to_2406.migrate"
+    profile="plonemeeting.portal.core:default"/>
+
 </configure>

--- a/src/plonemeeting/portal/core/migrations/migrate_to_2406.py
+++ b/src/plonemeeting/portal/core/migrations/migrate_to_2406.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from plone import api
+from plonemeeting.portal.core.migrations import PlonemeetingMigrator
+
+import logging
+
+
+logger = logging.getLogger("plonemeeting.portal.core")
+
+
+class MigrateTo2406(PlonemeetingMigrator):
+    def _store_meeting_type_on_meetings(self):
+        brains = self.catalog(portal_type="Meeting")
+        logger.info("Backfilling meeting_type on %d meetings", len(brains))
+        for brain in brains:
+            meeting = brain.getObject()
+            institution = api.portal.get_navigation_root(meeting)
+            meeting.meeting_type = getattr(institution, "meeting_type", None)
+
+    def run(self):
+        logger.info("Migrating to plonemeeting.portal.core 2406")
+        self._store_meeting_type_on_meetings()
+        logger.info("Migration to plonemeeting.portal.core 2406 done.")
+
+
+def migrate(context):
+    """Backfill the new Meeting.meeting_type field from each meeting's institution."""
+    migrator = MigrateTo2406(context)
+    migrator.run()
+    migrator.finish()

--- a/src/plonemeeting/portal/core/profiles/default/metadata.xml
+++ b/src/plonemeeting/portal/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <metadata>
-  <version>2405</version>
+  <version>2406</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-collective.z3cform.datagridfield:default</dependency>

--- a/src/plonemeeting/portal/core/sync_utils.py
+++ b/src/plonemeeting/portal/core/sync_utils.py
@@ -306,6 +306,7 @@ def sync_meeting_data(institution, meeting_data):
     )
     meeting.title = meeting_title
     meeting.date_time = _json_date_to_datetime(meeting_data.get("date"))
+    meeting.meeting_type = institution.meeting_type
     meeting.reindexObject()
     return meeting
 

--- a/src/plonemeeting/portal/core/tests/test_browser_utils.py
+++ b/src/plonemeeting/portal/core/tests/test_browser_utils.py
@@ -2,6 +2,7 @@
 
 from plone.api.exc import InvalidParameterError
 from plonemeeting.portal.core.tests.portal_test_case import PmPortalDemoFunctionalTestCase
+from plonemeeting.portal.core.utils import get_term_title
 
 
 class TestBrowserUtils(PmPortalDemoFunctionalTestCase):
@@ -30,6 +31,43 @@ class TestBrowserUtils(PmPortalDemoFunctionalTestCase):
         self.login_as_admin()
         utils_view = self.portal.restrictedTraverse("@@utils_view")
         self.assertEqual(meeting, utils_view.get_linked_meeting())
+
+    def test_get_current_meeting(self):
+        meeting = self.decisions["16-novembre-2018-08-30"]
+        item = meeting["approbation-du-pv-du-xxx"]
+        self.assertEqual(
+            meeting.restrictedTraverse("@@utils_view").get_current_meeting(), meeting
+        )
+        self.assertEqual(
+            item.restrictedTraverse("@@utils_view").get_current_meeting(), meeting
+        )
+
+    def test_meeting_type_falls_back_to_institution(self):
+        meeting = self.decisions["16-novembre-2018-08-30"]
+        # demo meetings predate the field: no stored value
+        self.assertIsNone(getattr(meeting, "meeting_type", None))
+        utils_view = meeting.restrictedTraverse("@@utils_view")
+        institution = self.portal["belleville"]
+        self.assertEqual(
+            utils_view.meeting_type(meeting),
+            get_term_title(institution, "meeting_type"),
+        )
+
+    def test_meeting_type_reads_from_meeting(self):
+        self.login_as_admin()
+        meeting = self.decisions["16-novembre-2018-08-30"]
+        meeting.meeting_type = "general-assembly"
+        utils_view = meeting.restrictedTraverse("@@utils_view")
+        self.assertEqual(
+            utils_view.meeting_type(meeting),
+            get_term_title(meeting, "meeting_type"),
+        )
+        # differs from the institution's default ("council")
+        institution = self.portal["belleville"]
+        self.assertNotEqual(
+            utils_view.meeting_type(meeting),
+            get_term_title(institution, "meeting_type"),
+        )
 
     def test_get_plonemeeting_last_modified_on_item(self):
         item = self.decisions["16-novembre-2018-08-30"]["approbation-du-pv-du-xxx"]

--- a/src/plonemeeting/portal/core/tests/test_browser_utils.py
+++ b/src/plonemeeting/portal/core/tests/test_browser_utils.py
@@ -43,9 +43,10 @@ class TestBrowserUtils(PmPortalDemoFunctionalTestCase):
         )
 
     def test_meeting_type_falls_back_to_institution(self):
+        self.login_as_admin()
         meeting = self.decisions["16-novembre-2018-08-30"]
-        # demo meetings predate the field: no stored value
-        self.assertIsNone(getattr(meeting, "meeting_type", None))
+        # force an empty value to exercise the institution fallback
+        meeting.meeting_type = None
         utils_view = meeting.restrictedTraverse("@@utils_view")
         institution = self.portal["belleville"]
         self.assertEqual(

--- a/src/plonemeeting/portal/core/tests/test_ct_meeting.py
+++ b/src/plonemeeting/portal/core/tests/test_ct_meeting.py
@@ -19,6 +19,15 @@ class MeetingIntegrationTest(PmPortalTestCase):
         schema = fti.lookupSchema()
         self.assertEqual(IMeeting, schema)
 
+    def test_ct_meeting_has_meeting_type_field(self):
+        self.assertIn("meeting_type", IMeeting)
+        field = IMeeting["meeting_type"]
+        self.assertEqual(field.default, "council")
+        self.assertEqual(
+            field.vocabularyName,
+            "plonemeeting.portal.vocabularies.meeting_types",
+        )
+
     def test_ct_meeting_fti(self):
         fti = queryUtility(IDexterityFTI, name="Meeting")
         self.assertTrue(fti)

--- a/src/plonemeeting/portal/core/tests/test_migrations.py
+++ b/src/plonemeeting/portal/core/tests/test_migrations.py
@@ -5,8 +5,9 @@ from plonemeeting.portal.core.tests.portal_test_case import PmPortalDemoFunction
 
 class TestMigrateTo2406(PmPortalDemoFunctionalTestCase):
     def test_backfills_meeting_type_from_institution(self):
-        # demo meetings predate the field: no stored value
-        self.assertIsNone(getattr(self.meeting, "meeting_type", None))
+        # set a value differing from the institution to prove the backfill overwrites it
+        self.meeting.meeting_type = "general-assembly"
+        self.assertNotEqual(self.meeting.meeting_type, self.institution.meeting_type)
         migrator = MigrateTo2406(self.portal.portal_setup)
         migrator.run()
         self.assertEqual(self.meeting.meeting_type, self.institution.meeting_type)

--- a/src/plonemeeting/portal/core/tests/test_migrations.py
+++ b/src/plonemeeting/portal/core/tests/test_migrations.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from plonemeeting.portal.core.migrations.migrate_to_2406 import MigrateTo2406
+from plonemeeting.portal.core.tests.portal_test_case import PmPortalDemoFunctionalTestCase
+
+
+class TestMigrateTo2406(PmPortalDemoFunctionalTestCase):
+    def test_backfills_meeting_type_from_institution(self):
+        # demo meetings predate the field: no stored value
+        self.assertIsNone(getattr(self.meeting, "meeting_type", None))
+        migrator = MigrateTo2406(self.portal.portal_setup)
+        migrator.run()
+        self.assertEqual(self.meeting.meeting_type, self.institution.meeting_type)

--- a/src/plonemeeting/portal/core/tests/test_sync.py
+++ b/src/plonemeeting/portal/core/tests/test_sync.py
@@ -73,6 +73,10 @@ class TestMeetingSynchronization(PmPortalDemoFunctionalTestCase):
         date_time = date_time.astimezone(pytz.timezone(timezone))
         self.assertEqual(meeting.date_time, date_time)
 
+    def test_sync_meeting_data_stores_meeting_type(self):
+        meeting = sync_meeting_data(self.institution, self.json_meeting.get("items")[0])
+        self.assertEqual(meeting.meeting_type, self.institution.meeting_type)
+
     def test_sync_meeting_items(self):
         meeting = sync_meeting_data(self.institution, self.json_meeting.get("items")[0])
         # only a few picked items


### PR DESCRIPTION
## DELIBE-318 — Store `meeting_type` on the Meeting

First step toward decoupling the iA.Délib configuration (enables the police-zone transition Conseil → Collège). Moves the source of truth for a meeting's *type* from the **Institution** to each **Meeting**. Observable behavior is unchanged: the value is copied from the institution.

### Changes
- **Schema**: `IMeeting.meeting_type` `Choice` (reuses the existing `meeting_types` vocabulary), placed in the `settings` fieldset so it is editable only by Zope admins.
- **Import**: `sync_meeting_data` copies `institution.meeting_type` onto each meeting (create + update).
- **Reads**: `UtilsView.get_current_meeting()` + `meeting_type(meeting=None)` read from the meeting, falling back to the institution. The three template call sites (`item.pt`, `preview_meeting.pt` ×2) now pass the in-scope `meeting`.
- **Migration**: upgrade step **2405 → 2406** backfills every meeting's `meeting_type` from its institution (`metadata.xml` bumped).

### Notes
- The field defaults to `council`, so the institution fallback in `meeting_type()` only triggers when a value is explicitly cleared.
- Because of that default, the migration overwrites `meeting_type` **unconditionally** from the institution — required so a non-council institution's meetings don't keep the wrong default.

### Out of scope (future decoupling)
Reading `meeting_type` from the API payload / per-meeting API config, and any catalog index / faceted filter on it.

### Tests
Full suite green: **240 tests, 0 failures, 0 errors**. New tests cover the schema field, import copy, read-from-meeting, institution fallback, context→meeting resolution, and the migration backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meetings now store a dedicated meeting type when imported and synchronized.
* **Bug Fixes**
  * Existing meetings are automatically backfilled during upgrade so their meeting type is populated from the institution.
  * Meeting type display is now consistent across public views and previews, using the meeting’s stored value with an institution fallback when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->