### PR TITLE
DELIBE-319: Be more defensive in _fetch_external_data_for_vocabulary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changelog
 - DELIBE-312: Fix an issue when an anonymous user was trying to access a private decision.
   Add a new comprehensive unit test `test_anonymous_unauthorized_item_view`.
   [aduchene]
+- DELIBE-319: Be more defensive in `_fetch_external_data_for_vocabulary`: when a meeting
+  config is disabled in iA.Delib, the `extra_include_*` key is missing from the response,
+  which raised a `KeyError`. Now log a warning and keep the previously saved values.
+  [aduchene]
 
 2.4.3 (2026-06-15)
 ------------------

--- a/src/plonemeeting/portal/core/content/institution.py
+++ b/src/plonemeeting/portal/core/content/institution.py
@@ -600,12 +600,23 @@ class Institution(Container):
                 try:
                     response = requests.get(url, auth=(self.username, self.password), headers=API_HEADERS)
                     if response.status_code in (200, 201):
-                        res = {}
                         json = response.json()
-                        values_json = json["extra_include_{}".format(url_extra_include)]
-                        for value in values_json:
-                            res[value[json_voc_value]] = value[json_voc_title]
-                        logger.info("Fetching {} for {} [End]".format(attr_name, self.title))
+                        extra_include_key = "extra_include_{}".format(url_extra_include)
+                        values_json = json.get(extra_include_key)
+                        if values_json is None:
+                            # The meeting config may be disabled in iA.Delib, in which case the
+                            # extra_include key is missing. Keep the previously saved values.
+                            logger.warning(
+                                "Missing '{}' while fetching {} for {}, "
+                                "keeping previously saved values [End]".format(
+                                    extra_include_key, attr_name, self.title
+                                )
+                            )
+                        else:
+                            res = {}
+                            for value in values_json:
+                                res[value[json_voc_value]] = value[json_voc_title]
+                            logger.info("Fetching {} for {} [End]".format(attr_name, self.title))
                     else:
                         logger.error("Unable to fetch {}, error is {} [End]".format(attr_name, response.content))
                 except requests.exceptions.ConnectionError as err:

--- a/src/plonemeeting/portal/core/tests/test_institution.py
+++ b/src/plonemeeting/portal/core/tests/test_institution.py
@@ -177,6 +177,19 @@ class TestInstitutionView(PmPortalDemoFunctionalTestCase):
         self.assertDictEqual(belleville.delib_categories, {})
         unstub()
 
+        # DELIBE-319: when the meeting config is disabled in iA.Delib, the response
+        # is a 200 but the extra_include key is missing. We must not raise a KeyError
+        # and gracefully keep the previously saved delib_categories.
+        belleville.delib_category_field = "category"
+        url = "https://demo-pm.imio.be/@config?config_id=meeting-config-college&extra_include=categories"
+        when(requests).get(url, auth=auth, headers=headers).thenReturn(
+            mock({"status_code": 200, "json": lambda: {}})
+        )
+        setattr(belleville, "delib_categories", {"admin": "Administrative", "political": "Political"})
+        belleville.fetch_delib_categories()
+        self.assertDictEqual({"admin": "Administrative", "political": "Political"}, belleville.delib_categories)
+        unstub()
+
     def test_load_representatives_from_delib(self):
         belleville = self.portal["belleville"]
         belleville.representatives_mappings = []


### PR DESCRIPTION
## Problem

When a meeting config is disabled in iA.Délib, the `@config` REST endpoint returns a `200` response that **omits** the `extra_include_*` key. `_fetch_external_data_for_vocabulary` accessed that key directly, raising:

\`\`\`
Module plonemeeting.portal.core.content.institution, line 605, in _fetch_external_data_for_vocabulary
KeyError: 'extra_include_categories'
\`\`\`

## Fix

Use `dict.get()` instead of direct subscription. When the key is missing, log a warning and keep the previously saved vocabulary values (consistent with the existing `ConnectionError` graceful fallback) instead of crashing.

## Test

Added a case to `test_load_category_from_delib` that returns a `200` with an empty JSON body and asserts the previously saved `delib_categories` are preserved and no `KeyError` is raised.

Ref: https://my.support.imio.be/browse/DELIBE-319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing meeting configuration data so the app no longer fails when expected response fields are absent.
  * Preserved previously saved category values when fresh data cannot be loaded, instead of clearing them or raising an error.

* **Tests**
  * Added coverage for the disabled-configuration scenario to ensure existing values remain intact and no error is thrown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->