### PR TITLE
DELIBE-317: Warn managers on unpublished publications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 2.4.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Warn managers viewing an unpublished publication that re-publishing it will
+  lose the existing qualified timestamp, and advise recreating it through the
+  supersede ("remplacé par") archiving system.
+  [DELIBE-317]
 
 
 2.4.4 (2026-07-09)

--- a/src/plonemeeting/portal/core/browser/templates/publication.pt
+++ b/src/plonemeeting/portal/core/browser/templates/publication.pt
@@ -34,6 +34,19 @@
           </div>
           <div class="alert-content" tal:content="structure institution/archived_publication_warning_text/output"></div>
         </div>
+        <div id="unpublished-alert" class="alert with-icon alert-warning" role="alert" tal:condition="python: not is_anon and review_state == 'unpublished'">
+          <div class="alert-icon">
+            <i class="bi bi-exclamation-triangle-fill"></i>
+          </div>
+          <div class="alert-content">
+            <p i18n:translate="">
+              This publication has been unpublished. If you publish it again, the existing qualified timestamp will be lost and the publication will be timestamped anew.
+            </p>
+            <p i18n:translate="">
+              We advise you to move this publication to the "archived" state (which does not invalidate the timestamp), to create a new publication and to use the "superseded by" field to link it to the new one.
+            </p>
+          </div>
+        </div>
         <div id="superseded_by-alert" class="alert with-icon alert-info" role="alert" tal:condition="python: timeline and timeline[0]['current'] is False">
           <div class="alert-icon">
             <i class="bi bi-info-circle"></i>

--- a/src/plonemeeting/portal/core/locales/fr/LC_MESSAGES/plonemeeting.portal.core.po
+++ b/src/plonemeeting/portal/core/locales/fr/LC_MESSAGES/plonemeeting.portal.core.po
@@ -796,6 +796,10 @@ msgstr "Page vers laquelle les visiteurs seront redirigé quand ils cliquent sur
 msgid "This behavior adds supersede functionality to a content type."
 msgstr "Ce behavior ajoute la fonctionnalité de remplacement à un type de contenu."
 
+#: ../browser/templates/publication.pt:38
+msgid "This publication has been unpublished. If you publish it again, the existing qualified timestamp will be lost and the publication will be timestamped anew."
+msgstr "Cette publication a été dépubliée. Si vous la publiez de nouveau, l'horodatage qualifié existant sera perdu et la publication sera horodatée à nouveau."
+
 #: ../browser/templates/publication.pt:340
 msgid "Timeline"
 msgstr ""
@@ -869,6 +873,10 @@ msgstr "Voir la séance"
 #: ../profiles/default/registry.xml
 msgid "Ville/Commune"
 msgstr "Ville/Commune"
+
+#: ../browser/templates/publication.pt:42
+msgid "We advise you to move this publication to the \"archived\" state (which does not invalidate the timestamp), to create a new publication and to use the \"superseded by\" field to link it to the new one."
+msgstr "Il est conseillé de passer cette publication à l'état « archivé » (ce qui n'invalide pas l'horodatage), de recréer une nouvelle publication et d'utiliser le champ « remplacé par » pour la lier à la nouvelle."
 
 #: ../browser/manage_users.py:53
 msgid "We will use this address if you need to recover your password"

--- a/src/plonemeeting/portal/core/locales/plonemeeting.portal.core.pot
+++ b/src/plonemeeting/portal/core/locales/plonemeeting.portal.core.pot
@@ -795,6 +795,10 @@ msgstr ""
 msgid "This behavior adds supersede functionality to a content type."
 msgstr ""
 
+#: ../browser/templates/publication.pt:38
+msgid "This publication has been unpublished. If you publish it again, the existing qualified timestamp will be lost and the publication will be timestamped anew."
+msgstr ""
+
 #: ../browser/templates/publication.pt:340
 msgid "Timeline"
 msgstr ""
@@ -867,6 +871,10 @@ msgstr ""
 
 #: ../profiles/default/registry.xml
 msgid "Ville/Commune"
+msgstr ""
+
+#: ../browser/templates/publication.pt:42
+msgid "We advise you to move this publication to the \"archived\" state (which does not invalidate the timestamp), to create a new publication and to use the \"superseded by\" field to link it to the new one."
 msgstr ""
 
 #: ../browser/manage_users.py:53

--- a/src/plonemeeting/portal/core/tests/test_publication.py
+++ b/src/plonemeeting/portal/core/tests/test_publication.py
@@ -192,7 +192,12 @@ class TestPublicationView(PmPortalDemoFunctionalTestCase):
 
         self.login_as_publications_manager()
         view = self.unpublished_publication.restrictedTraverse("@@view")
-        self.assertTrue(view())
+        rendered = view()
+        self.assertTrue(rendered)
+        # The unpublished warning is shown to managers, but not on a published publication
+        self.assertIn("unpublished-alert", rendered)
+        published_rendered = self.published_publication.restrictedTraverse("@@view")()
+        self.assertNotIn("unpublished-alert", published_rendered)
         view = self.unpublished_publication.restrictedTraverse("@@edit")
         self.assertTrue(view())
         ILockable(self.unpublished_publication).unlock()


### PR DESCRIPTION
Adds a warning on the **Publication** view, shown to managers when a publication is in the **unpublished** state.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible warning on unpublished publications, explaining that republishing will remove the existing qualified timestamp and recommending an archived replacement workflow.
* **Documentation**
  * Updated release notes with guidance about unpublished publications and republishing behavior.
* **Bug Fixes**
  * Added translations for the new warning messages in English and French.
* **Tests**
  * Expanded coverage to ensure the warning appears for unpublished publications and not for published ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->